### PR TITLE
NHQueryHelper formatter fix

### DIFF
--- a/Breeze.ContextProvider.NH/NHQueryHelper.cs
+++ b/Breeze.ContextProvider.NH/NHQueryHelper.cs
@@ -170,7 +170,11 @@ namespace Breeze.ContextProvider.NH
                 if (error is LazyInitializationException || error is ObjectDisposedException)
                     args.ErrorContext.Handled = true;
             };
-            settings.Converters.Add(new NHibernateProxyJsonConverter());
+
+            if (!settings.Converters.Any(c => c is NHibernateProxyJsonConverter))
+            {
+                settings.Converters.Add(new NHibernateProxyJsonConverter());
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Each instance of theNHQueryHelper adds a new instance to the list of Converters. This leads to wasted memory, and secondly an occasional race condition where some of the converters are set to null and an exception in Json.Net is raised.

This fix simply checks whether a converter needs to be added before adding one.
