### PR TITLE
EFEntityError - Fixed issue where ErrorName is never set

### DIFF
--- a/Breeze.ContextProvider.EF6/EFContextProvider.cs
+++ b/Breeze.ContextProvider.EF6/EFContextProvider.cs
@@ -804,7 +804,7 @@ namespace Breeze.ContextProvider.EF6 {
         this.EntityTypeName = entityInfo.Entity.GetType().FullName;
         this.KeyValues = GetKeyValues(entityInfo);
       }
-      ErrorName = ErrorName;
+      ErrorName = errorName;
       ErrorMessage = errorMessage;
       PropertyName = propertyName;
     }


### PR DESCRIPTION
In the constructor for EFEntityError, the ErrorName property gets set to
itself, rather than the errorName parameter. This effectively always
leads to an ErrorName of null. This commit fixes up the property
setting.