### PR TITLE
return only metadata related to static types and not dynamic ones

### DIFF
--- a/Breeze.ContextProvider.NH/NHBreezeMetadata.cs
+++ b/Breeze.ContextProvider.NH/NHBreezeMetadata.cs
@@ -46,7 +46,8 @@ namespace Breeze.ContextProvider.NH
         {
             InitMap();
 
-            IDictionary<string, IClassMetadata> classMeta = _sessionFactory.GetAllClassMetadata();
+            // retrieves all mappings with the name property set on the class  (mapping with existing type, no duck typing)
+            IDictionary<string, IClassMetadata> classMeta = _sessionFactory.GetAllClassMetadata().Where(p => ((IEntityPersister)p.Value).EntityMetamodel.Type != null).ToDictionary(p => p.Key, p => p.Value);
             //IDictionary<string, ICollectionMetadata> collectionMeta = _sessionFactory.GetAllCollectionMetadata();
 
             foreach (var meta in classMeta.Values)

--- a/Breeze.ContextProvider.NH/NHMetadataBuilder.cs
+++ b/Breeze.ContextProvider.NH/NHMetadataBuilder.cs
@@ -43,7 +43,8 @@ namespace Breeze.ContextProvider.NH
         {
             InitMap();
 
-            IDictionary<string, IClassMetadata> classMeta = _sessionFactory.GetAllClassMetadata();
+            // retrieves all mappings with the name property set on the class  (mapping with existing type, no duck typing)
+            IDictionary<string, IClassMetadata> classMeta = _sessionFactory.GetAllClassMetadata().Where(p => ((IEntityPersister)p.Value).EntityMetamodel.Type != null).ToDictionary(p => p.Key, p => p.Value);
 
             foreach (var meta in classMeta.Values)
             {


### PR DESCRIPTION
http://stackoverflow.com/questions/26400078/breeze-building-metadata-with-the-nhmetadatabuilder-when-using-envers

We had an issue using NHibernate Envers. Envers adds dynamic types mappings(_aud tables) and those mappings can't be used with breeze. The workaround is to get only mappings which have the Type property not null in EntityMetaModel.
