### PR TITLE
InlineCount executed 2 times in specific cases bug fix

### DIFF
--- a/Breeze.WebApi2/QueryHelper.cs
+++ b/Breeze.WebApi2/QueryHelper.cs
@@ -94,10 +94,14 @@ namespace Breeze.WebApi2 {
         newQueryOptions = QueryHelper.RemoveSelectExpandOrderBy(newQueryOptions);
       }
 
-
       if (newQueryOptions == queryOptions) {
         return queryOptions.ApplyTo(queryable, querySettings);
       } else {
+        // remove inlinecount or it will be executed two times
+        if (newQueryOptions.InlineCount != null)
+        {
+            newQueryOptions = QueryHelper.RemoveInlineCount(newQueryOptions);
+        }
         // apply default processing first with "unsupported" stuff removed. 
         var q = newQueryOptions.ApplyTo(queryable, querySettings);
         // then apply unsupported stuff. 
@@ -125,6 +129,11 @@ namespace Breeze.WebApi2 {
     public static ODataQueryOptions RemoveSelectExpandOrderBy(ODataQueryOptions queryOptions) {
       var optionsToRemove = new List<String>() { "$select", "$expand", "$orderby", "$top", "$skip" };
       return RemoveOptions(queryOptions, optionsToRemove);
+    }
+
+    public static ODataQueryOptions RemoveInlineCount(ODataQueryOptions queryOptions) {
+       var optionsToRemove = new List<String>() { "$inlinecount" };
+       return RemoveOptions(queryOptions, optionsToRemove);
     }
 
     public static ODataQueryOptions RemoveOptions(ODataQueryOptions queryOptions, List<String> optionNames) {

--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@ breeze.server.net
 =================
 
 Breeze support for .NET servers
+
+See http://breeze.github.io/doc-net/


### PR DESCRIPTION
Don't know what happened with the previous pull request bu git got lost with some casing issues...
So, it should fix the inlinecount query executed two times in specific cases(expand, select, orderby).
The bug happens with both EF and NHibernate.
To test, you can query and use a $expand or $select.