### PR TITLE
Bug fix for formula

### DIFF
--- a/Breeze.ContextProvider.NH/NHMetadataBuilder.cs
+++ b/Breeze.ContextProvider.NH/NHMetadataBuilder.cs
@@ -554,6 +554,11 @@ namespace Breeze.ContextProvider.NH
                 var propType = propTypes[i];
                 if (propType.IsAssociationType) continue;
                 var columnArray = persister.GetPropertyColumnNames(i);
+                // HACK for NHibernate formula: when using formula GetPropertyColumnNames(i) returns an array with the first element null
+                if (columnArray[0] == null)
+                {
+                    continue;
+                }
                 if (NamesEqual(columnArray, columnNames)) return new string[] { propName };
             }
 


### PR DESCRIPTION
This is the same kind of bug I fixed in this pull request https://github.com/Breeze/breeze.server.net/pull/4
`NHMetadataBuilder` was crashing(in `GetPropertyNamesForColumns`) due to a formula