### PR TITLE
Exception handling with NHibernate and TransactionType.DbTransaction

### DIFF
--- a/Breeze.ContextProvider.NH/NHContext.cs
+++ b/Breeze.ContextProvider.NH/NHContext.cs
@@ -241,7 +241,7 @@ namespace Breeze.ContextProvider.NH {
         });
         saveWorkState.EntityErrors = entityErrors;
       } catch (Exception) {
-        if (tx.IsActive) tx.Rollback();
+        if (!hasExistingTransaction) tx.Rollback();
         throw;
       } finally {
         if (!hasExistingTransaction) tx.Dispose();


### PR DESCRIPTION
The transaction is rollbacked two times when using `TransactionType.DbTransaction` and the original exception is replaced by this one:

```
System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'AdoTransaction'.
   at NHibernate.Transaction.AdoTransaction.CheckNotDisposed()
   at NHibernate.Transaction.AdoTransaction.Rollback()
```