### PR TITLE
re-encode querystring parameters in RemoveOptions

### DIFF
--- a/Breeze.WebApi2/QueryHelper.cs
+++ b/Breeze.WebApi2/QueryHelper.cs
@@ -7,6 +7,7 @@ using System.Linq.Expressions;
 using System.Net.Http;
 using System.Net.Http.Formatting;
 using System.Reflection;
+using System.Web;
 using System.Web.Http.OData.Query;
 
 namespace Breeze.WebApi2 {
@@ -142,9 +143,10 @@ namespace Breeze.WebApi2 {
       var oldUri = request.RequestUri;
 
       var map = oldUri.ParseQueryString();
+      // after ParseQueryString, all the values are decoded. We need to encode everything before applying to odata
       var newQuery = map.Keys.Cast<String>()
                         .Where(k => (k.Trim().Length > 0) && !optionNames.Contains(k.Trim()))
-                        .Select(k => k + "=" + map[k])
+                        .Select(k => k + "=" + HttpUtility.UrlEncode(map[k]))
                         .ToAggregateString("&");
 
       var newUrl = oldUri.Scheme + "://" + oldUri.Authority + oldUri.AbsolutePath + "?" + newQuery;


### PR DESCRIPTION
I found an issue when executing a query with special characters(& or %).
Try a query with the same parameters:

> https://localhost/webapi/breeze/eai/Requests?$filter=substringof(%27q%26a%27%2CAssignedTo)%20eq%20true&$orderby=RequestIdentifier%20desc&$expand=Client

I'm filtering a field called AssignedTo searching if it contains "q&A" AND doing an expand. It will fail with the following error message:
`"$id": "1",
"$type": "System.Web.Http.HttpError, System.Web.Http",
"Message": "The query specified in the URI is not valid. There is an unterminated string literal at position 14 in 'substringof('q'.",
"ExceptionMessage": "There is an unterminated string literal at position 14 in 'substringof('q'.",
"ExceptionType": "Microsoft.Data.OData.ODataException",
"StackTrace": "   at Microsoft.Data.OData.Query.ExpressionLexer.NextToken()\r\n   at Microsoft.Data.OData.Query.FunctionCallParser.ParseArgumentList()\r\n   at Microsoft.Data.OData.Query.FunctionCallParser.ParseIdentifierAsFunction(QueryToken parent)\r\n   at Microsoft.Data.OData.Query.IdentifierTokenizer.ParseIdentifier(QueryToken parent)\r\n   at Microsoft.Data.OData.Query.UriQueryExpressionParser.ParsePrimary()\r\n   at Microsoft.Data.OData.Query.UriQueryExpressionParser.ParseUnary()\r\n   at Microsoft.Data.OData.Query.UriQueryExpressionParser.ParseMultiplicative()\r\n   at Microsoft.Data.OData.Query.UriQueryExpressionParser.ParseAdditive()\r\n   at Microsoft.Data.OData.Query.UriQueryExpressionParser.ParseComparison()\r\n   at Microsoft.Data.OData.Query.UriQueryExpressionParser.ParseLogicalAnd()\r\n   at Microsoft.Data.OData.Query.UriQueryExpressionParser.ParseLogicalOr()\r\n   at Microsoft.Data.OData.Query.UriQueryExpressionParser.ParseExpression()\r\n   at Microsoft.Data.OData.Query.UriQueryExpressionParser.ParseFilter(String filter)\r\n   at Microsoft.Data.OData.Query.ODataUriParser.ParseFilterImplementation(String filter, IEdmType elementType, IEdmEntitySet entitySet)\r\n   at System.Web.Http.OData.Query.FilterQueryOption.get_FilterClause()\r\n   at System.Web.Http.OData.Query.FilterQueryOption.ApplyTo(IQueryable query, ODataQuerySettings querySettings, IAssembliesResolver assembliesResolver)\r\n   at System.Web.Http.OData.Query.ODataQueryOptions.ApplyTo(IQueryable query, ODataQuerySettings querySettings)\r\n   at Breeze.WebApi2.QueryHelper.ApplyQuery(IQueryable queryable, ODataQueryOptions queryOptions, ODataQuerySettings querySettings) in c:\\dev\\breeze.server.net\\Breeze.WebApi2\\QueryHelper.cs:line 107\r\n   at Breeze.WebApi2.EnableBreezeQueryAttribute.ApplyQuery(IQueryable queryable, ODataQueryOptions queryOptions) in c:\\dev\\breeze.server.net\\Breeze.WebApi2\\EnableBreezeQueryAttribute.cs:line 141\r\n   at System.Web.Http.OData.EnableQueryAttribute.OnActionExecuted(HttpActionExecutedContext actionExecutedContext)"`

The issue comes from this code:

```
public static ODataQueryOptions RemoveOptions(ODataQueryOptions queryOptions, List<String> optionNames) {
      var request = queryOptions.Request;
      var oldUri = request.RequestUri;

      var map = oldUri.ParseQueryString();
      var newQuery = map.Keys.Cast<String>()
                        .Where(k => (k.Trim().Length > 0) && !optionNames.Contains(k.Trim()))
                        .Select(k => k + "=" + map[k])
                        .ToAggregateString("&");

      var newUrl = oldUri.Scheme + "://" + oldUri.Authority + oldUri.AbsolutePath + "?" + newQuery;
      var newUri = new Uri(newUrl);

      var newRequest = new HttpRequestMessage(request.Method, newUri);
      var newQo = new ODataQueryOptions(queryOptions.Context, newRequest);
      return newQo;
    }
```

The `ParseQueryString` method decodes the url and the encoded characters are not encoded anymore. When the new ODataQueryOptions is applied to the IQueryable it fails:
` 
// apply default processing first with "unsupported" stuff removed. 
var q = newQueryOptions.ApplyTo(queryable, querySettings);
`

It happens only if you mix the substring with a $expand, $orderby(on children) or $select. If you remove the $expand from the query at the top it works.

I fixed it by re-encoding the parameters individually before constructing the new url.
