### PR TITLE
BreezeConfig.Instance fails to instantiate custom implementations

### DIFF
--- a/AspNetCore/Breeze.Persistence/BreezeConfig.cs
+++ b/AspNetCore/Breeze.Persistence/BreezeConfig.cs
@@ -19,7 +19,7 @@ namespace Breeze.Persistence {
           AppDomain.CurrentDomain.AssemblyLoad += CurrentDomain_AssemblyLoad;
           if (__instance == null) {
             var typeCandidates = ProbeAssemblies.SelectMany(a => GetTypes(a));
-            var types = typeCandidates.Where(t => typeof (BreezeConfig).IsAssignableFrom(t) && !t.IsAbstract).ToList();
+            var types = typeCandidates.Where(t => t != typeof(BreezeConfig) && typeof (BreezeConfig).IsAssignableFrom(t) && !t.IsAbstract).ToList();
 
             if (types.Count == 0) {
               __instance = new BreezeConfig();


### PR DESCRIPTION
Fixing a bug where BreezeConfig.Instance cannot instantiate a custom BreezeConfig implementation due to failing to filter out the Breeze.Persistence assembly's own BreezeConfig.