### PR TITLE
EF2.2

### DIFF
--- a/AspNetCore/Breeze.AspNetCore.NetCore/Breeze.AspNetCore.NetCore.csproj
+++ b/AspNetCore/Breeze.AspNetCore.NetCore/Breeze.AspNetCore.NetCore.csproj
@@ -29,8 +29,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.OData" Version="7.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AspNetCore/Breeze.AspNetCore.NetCore/EnableBreezeQueryAttribute.cs
+++ b/AspNetCore/Breeze.AspNetCore.NetCore/EnableBreezeQueryAttribute.cs
@@ -1,0 +1,175 @@
+﻿using Microsoft.AspNet.OData;
+using Microsoft.AspNet.OData.Query;
+using Microsoft.AspNetCore.Mvc.Filters;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+//using System.Net.Http;
+using Microsoft.AspNetCore.Http;
+using System.Text;
+using Breeze.AspNetCore.NetCore;
+using Microsoft.AspNet.OData.Extensions;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Breeze.Persistence.EFCore
+{
+    /// <summary>
+    /// Extend Web API's <see cref="EnableQueryAttribute"/>
+    /// for expected Breeze OData-like query support.
+    /// </summary>
+    /// <remarks>
+    /// Remember to add it to the Filters for your configuration.
+    /// Automatically added to each IQueryable method when
+    /// you put the [BreezeController] attribute on an ApiController class.
+    /// <para>
+    /// See also http://blogs.msdn.com/b/webdev/archive/2014/03/13/getting-started-with-asp-net-web-api-2-2-for-odata-v4-0.aspx
+    /// </para>
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, Inherited = true, AllowMultiple = false)]
+    public class EnableBreezeQueryAttribute : EnableQueryAttribute
+    {
+
+        private static string QUERY_HELPER_KEY = "EnableBreezeQueryAttribute_QUERY_HELPER_KEY";
+
+        public EnableBreezeQueryAttribute()
+        {
+            // ensure EnableQueryAttribute supports Expand and Select by default because Breeze does.
+            // Todo: confirm that this is still necessary as it was for predecessor QueryableAttribute
+            this.AllowedQueryOptions = AllowedQueryOptions.Supported | AllowedQueryOptions.Expand | AllowedQueryOptions.Select;
+        }
+
+        private Uri RequestUri = null;
+
+        /// <summary>
+        /// Get the QueryHelper instance for the current request.  We use a single instance per request because
+        /// QueryHelper is stateful, and may preserve state between the ApplyQuery and OnActionExecuted methods.
+        /// </summary>
+        /// <param name="request"></param>
+        /// <returns></returns>
+        protected QueryHelper GetQueryHelper(HttpRequest request)
+        {
+            this.RequestUri = new Uri(request.Scheme + "://" + request.Host + (request.Path.HasValue ? request.Path.Value : String.Empty) + (request.QueryString.HasValue ? request.QueryString.Value : String.Empty));
+            object qh;
+            if (!request.HttpContext.Items.TryGetValue(QUERY_HELPER_KEY, out qh))
+            {
+                qh = NewQueryHelper();
+                request.HttpContext.Items.Add(QUERY_HELPER_KEY, qh);
+            }
+            return (QueryHelper)qh;
+        }
+
+        protected virtual QueryHelper NewQueryHelper()
+        {
+            return new QueryHelper(GetODataQuerySettings());
+        }
+
+        public ODataQuerySettings GetODataQuerySettings()
+        {
+            var settings = new ODataQuerySettings
+            {
+                EnableConstantParameterization = this.EnableConstantParameterization,
+                EnsureStableOrdering = this.EnsureStableOrdering,
+                HandleNullPropagation = this.HandleNullPropagation,
+                PageSize = this.PageSize > 0 ? this.PageSize : (int?)null
+            };
+            return settings;
+        }
+
+        /// <summary>
+        /// Called when the action is executed.  If the return type is IEnumerable or IQueryable,
+        /// calls OnActionExecuted in the base class, which in turn calls ApplyQuery.
+        /// </summary>
+        /// <param name="actionExecutedContext">The action executed context.</param>
+        public override void OnActionExecuted(ActionExecutedContext actionExecutedContext)
+        {
+            var response = actionExecutedContext.HttpContext.Response;
+            if (response == null)
+            {
+                return;
+            }
+            object responseObject = (actionExecutedContext.Result as ObjectResult)?.Value;
+            if (responseObject == null)
+            {
+                return;
+            }
+
+            var request = actionExecutedContext.HttpContext.Request;
+            var returnType = (actionExecutedContext.Result as ObjectResult).Value?.GetType();
+            var queryHelper = GetQueryHelper(request);
+
+            try
+            {
+                if (!response.IsSuccessStatusCode())
+                {
+                    return;
+                }
+                if (typeof(IEnumerable).IsAssignableFrom(returnType) || responseObject is IEnumerable)
+                {
+                    // We think that EnableQueryAttribute only applies for IQueryable and IEnumerable return types
+                    // Our version calls ValidateQuery and then ApplyQuery
+                    // Todo: confirm that this is still necessary as it was for predecessor QueryableAttribute
+                    base.OnActionExecuted(actionExecutedContext);
+                    if (!actionExecutedContext.HttpContext.Response.IsSuccessStatusCode())
+                    {
+                        return;
+                    }
+                    responseObject = (actionExecutedContext.Result as ObjectResult)?.Value;
+                    if (responseObject == null)
+                    {
+                        return;
+                    }
+                    var queryResult = responseObject as IQueryable;
+                    if (queryResult == null && responseObject is IEnumerable)
+                        queryResult = (responseObject as IEnumerable).AsQueryable();
+                    queryHelper.WrapResult(request, actionExecutedContext, queryResult);
+                }
+                // For non-IEnumerable results, post-processing must be done manually by the developer.
+                queryHelper.ConfigureFormatter(actionExecutedContext, responseObject as IQueryable);
+            }
+            finally
+            {
+                queryHelper.Close(responseObject);
+            }
+        }
+
+        public override void ValidateQuery(HttpRequest request, ODataQueryOptions queryOptions)
+        {
+            try
+            {
+                base.ValidateQuery(request, queryOptions);
+            }
+            catch (Exception e)
+            {
+                // Ignore error if its message is like "Only properties specified in $expand can be traversed in $select query options"
+                // because Breeze CAN support this by bypassing the OData processing.
+                if (!(e.Message.Contains("$expand") && e.Message.Contains("$select")))
+                {
+                    //if (e.Message.Contains("$orderby") && e.Message.Contains("TableName"))
+                    //    return;
+                    //throw; // any other error
+                }
+            }
+        }
+
+        /// <summary>
+        /// All standard OData web api support is handled here (except select and expand).
+        /// This method also handles nested orderby statements the the current ASP.NET web api does not yet support.
+        /// This method is called by base.OnActionExecuted
+        /// </summary>
+        /// <param name="queryable"></param>
+        /// <param name="queryOptions"></param>
+        /// <returns></returns>
+        public override IQueryable ApplyQuery(IQueryable queryable, ODataQueryOptions queryOptions)
+        {
+
+            var queryHelper = GetQueryHelper(queryOptions.Request);
+
+            queryable = queryHelper.BeforeApplyQuery(queryable, queryOptions);
+            queryable = queryHelper.ApplyQuery(queryable, queryOptions);
+            return queryable;
+        }
+
+    }
+
+}

--- a/AspNetCore/Breeze.AspNetCore.NetCore/QueryHelper.cs
+++ b/AspNetCore/Breeze.AspNetCore.NetCore/QueryHelper.cs
@@ -1,0 +1,408 @@
+﻿using Breeze.Core;
+using Microsoft.AspNet.OData.Query;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+//using System.Net.Http;
+using Microsoft.AspNetCore.Http;
+using System.Reflection;
+using System.Text;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json;
+using Microsoft.EntityFrameworkCore;
+
+namespace Breeze.AspNetCore.NetCore
+{
+    public class QueryHelper
+    {
+        protected ODataQuerySettings querySettings;
+
+        public QueryHelper(ODataQuerySettings querySettings)
+        {
+            this.querySettings = querySettings;
+        }
+
+        public QueryHelper(bool enableConstantParameterization, bool ensureStableOrdering, HandleNullPropagationOption handleNullPropagation, int? pageSize)
+        {
+            this.querySettings = NewODataQuerySettings(enableConstantParameterization, ensureStableOrdering, handleNullPropagation, pageSize);
+        }
+
+        public QueryHelper()
+          : this(true, true, HandleNullPropagationOption.False, null)
+        {
+        }
+
+        public static ODataQuerySettings NewODataQuerySettings(bool enableConstantParameterization, bool ensureStableOrdering, HandleNullPropagationOption handleNullPropagation, int? pageSize)
+        {
+            var settings = new ODataQuerySettings()
+            {
+                EnableConstantParameterization = enableConstantParameterization,
+                EnsureStableOrdering = ensureStableOrdering,
+                HandleNullPropagation = handleNullPropagation,
+                PageSize = pageSize > 0 ? pageSize : null
+            };
+            return settings;
+        }
+
+        // Controls whether we always handle expands (vs. letting WebApi take care of it)
+        public virtual bool ManuallyExpand { get { return false; } }
+
+        /// <summary>
+        /// Provide a hook to do any processing before applying the query.  This implementation does nothing.
+        /// </summary>
+        /// <param name="queryable"></param>
+        /// <param name="queryOptions"></param>
+        /// <returns></returns>
+        public virtual IQueryable BeforeApplyQuery(IQueryable queryable, ODataQueryOptions queryOptions)
+        {
+            return queryable;
+        }
+
+
+        public IQueryable ApplyQuery(IQueryable queryable, ODataQueryOptions queryOptions)
+        {
+            return ApplyQuery(queryable, queryOptions, this.querySettings);
+        }
+
+        /// <summary>
+        /// Apply the queryOptions to the query.  
+        /// This method handles nested order-by statements the the current ASP.NET web api does not yet support.
+        /// </summary>
+        /// <param name="queryable"></param>
+        /// <param name="queryOptions"></param>
+        /// <param name="querySettings"></param>
+        /// <returns></returns>
+        public IQueryable ApplyQuery(IQueryable queryable, ODataQueryOptions queryOptions, ODataQuerySettings querySettings)
+        {
+
+            // HACK: this is a hack because on a bug in querySettings.EnsureStableOrdering = true that overrides
+            // any existing order by clauses, instead of appending to them.
+            querySettings.EnsureStableOrdering = false;
+
+            // Basic idea here is the current WebApi OData cannot support the following operations
+            // 1) "orderby" with  nested properties
+            // 2) "select" with complex types
+            // 3) "selects" of "nested" properties unless accompanied by the appropriate "expand".  
+            //     i.e. can't do Customers.select("orders") unless we also add expand("orders")
+
+            // The workaround here is to bypass "select" and "orderBy" processing under these conditions 
+            // This involves removing the "offending" queryOptions before asking the WebApi2 OData processing to do its thing
+            // and then post processing the resulting IQueryable. 
+            // We actually do this with all selects because it's easier than trying to determine if they are actually problematic. 
+
+            // Another approach that DOESN'T work is to let WebApi2 OData try to do it stuff and then only handle the cases where it throws an exception.
+            // This doesn't work because WebApi2 OData will actually just skip the portions of the query that it can't process and return what it can ( under some conditions). 
+
+            var expandQueryString = queryOptions.RawValues.Expand;
+            var orderByQueryString = queryOptions.RawValues.OrderBy;
+            var selectQueryString = queryOptions.RawValues.Select;
+
+            ODataQueryOptions newQueryOptions = queryOptions;
+            if (!string.IsNullOrWhiteSpace(selectQueryString))
+            {
+                newQueryOptions = QueryHelper.RemoveSelectExpandOrderBy(newQueryOptions);
+            }
+            else if ((!string.IsNullOrWhiteSpace(orderByQueryString)) && orderByQueryString.IndexOf('/') >= 0)
+            {
+                newQueryOptions = QueryHelper.RemoveSelectExpandOrderBy(newQueryOptions);
+            }
+            else if (ManuallyExpand && !string.IsNullOrWhiteSpace(expandQueryString))
+            {
+                newQueryOptions = QueryHelper.RemoveSelectExpandOrderBy(newQueryOptions);
+            }
+
+
+            if (newQueryOptions == queryOptions)
+            {
+                return queryOptions.ApplyTo(queryable, querySettings);
+            }
+            else
+            {
+                // remove inlinecount or it will be executed two times
+                if (newQueryOptions.Count != null)
+                {
+                    newQueryOptions = QueryHelper.RemoveInlineCount(newQueryOptions);
+                }
+
+                // apply default processing first with "unsupported" stuff removed. 
+                var q = newQueryOptions.ApplyTo(queryable, querySettings);
+                // then apply unsupported stuff. 
+
+                string inlinecountString = queryOptions.RawValues.Count;
+                if (!string.IsNullOrWhiteSpace(inlinecountString))
+                {
+                    if (inlinecountString == "allpages")
+                    {
+                        var inlineCount = (Int64)Queryable.Count((dynamic)q);
+                        //queryOptions.Request.SetInlineCount(inlineCount);
+                    }
+                }
+
+                q = ApplyOrderBy(q, queryOptions);
+                var q2 = ApplySelect(q, queryOptions);
+                if (q2 == q)
+                {
+                    q2 = ApplyExpand(q, queryOptions);
+                }
+
+                return q2;
+            }
+
+
+        }
+
+        public static ODataQueryOptions RemoveSelectExpandOrderBy(ODataQueryOptions queryOptions)
+        {
+            var optionsToRemove = new List<String>() { "$select", "$expand", "$orderby", "$top", "$skip" };
+            return RemoveOptions(queryOptions, optionsToRemove);
+        }
+
+        public static ODataQueryOptions RemoveInlineCount(ODataQueryOptions queryOptions)
+        {
+            var optionsToRemove = new List<String>() { "$inlinecount" };
+            return RemoveOptions(queryOptions, optionsToRemove);
+        }
+
+        public static ODataQueryOptions RemoveOptions(ODataQueryOptions queryOptions, List<String> optionNames)
+        {
+            var request = queryOptions.Request;
+            //var oldUri = new Uri(queryOptions.Request.QueryString.ToString());
+            var oldUri = new Uri($"{request.Scheme}://{request.Host}{request.Path.ToString().TrimEnd('/')}/{request.QueryString}");
+
+            var map = Microsoft.AspNetCore.WebUtilities.QueryHelpers.ParseQuery(oldUri.Query).Where(d => (d.Key.Trim().Length > 0) && !optionNames.Contains(d.Key.Trim()))
+                .Select(d => new KeyValuePair<string, string>(d.Key, d.Value));
+
+            var qb = new Microsoft.AspNetCore.Http.Extensions.QueryBuilder(map);
+            var newUrl = oldUri.Scheme + "://" + oldUri.Authority + oldUri.AbsolutePath.TrimEnd('/') + "/" + qb.ToQueryString();
+            //var newUri = new Uri(newUrl);
+
+            //request.Path = new PathString(newUrl);
+            request.QueryString = qb.ToQueryString();
+            var newQo = new ODataQueryOptions(queryOptions.Context, request);
+            return newQo;
+            //return queryOptions;
+        }
+
+
+        /// <summary>
+        /// Apply the select clause to the queryable
+        /// </summary>
+        /// <param name="queryable"></param>
+        /// <param name="selectQueryString"></param>
+        /// <returns></returns>
+        public virtual IQueryable ApplySelect(IQueryable queryable, ODataQueryOptions queryOptions)
+        {
+            var selectQueryString = queryOptions.RawValues.Select;
+            if (string.IsNullOrEmpty(selectQueryString)) return queryable;
+            var selectClauses = selectQueryString.Split(',').Select(sc => sc.Replace('/', '.')).ToList();
+            var elementType = TypeFns.GetElementType(queryable.GetType());
+            var func = QueryBuilder.BuildSelectFunc(elementType, selectClauses);
+            return func(queryable);
+        }
+
+        /// <summary>
+        /// Apply to expands clause to the queryable
+        /// </summary>
+        /// <param name="queryable"></param>
+        /// <param name="expandsQueryString"></param>
+        /// <returns></returns>
+        public virtual IQueryable ApplyExpand(IQueryable queryable, ODataQueryOptions queryOptions)
+        {
+            var expandQueryString = queryOptions.RawValues.Expand;
+            if (string.IsNullOrEmpty(expandQueryString)) return queryable;
+            var eleType = TypeFns.GetElementType(queryable.GetType());
+            expandQueryString.Split(',').Select(s => s.Trim()).ToList().ForEach(expand => {
+                //queryable = ((dynamic)queryable).Include(expand.Replace('/', '.'));
+                var method = TypeFns.GetMethodByExample((IQueryable<String> q) => EntityFrameworkQueryableExtensions.Include<String>(q, "dummyPath"), eleType);
+                var func = QueryBuilder.BuildIQueryableFunc(eleType, method, expand);
+                queryable = func(queryable);
+            });
+            return queryable;
+        }
+
+
+        public virtual IQueryable ApplyOrderBy(IQueryable queryable, ODataQueryOptions queryOptions)
+        {
+            var elementType = TypeFns.GetElementType(queryable.GetType());
+            var result = queryable;
+
+            var orderByString = queryOptions.RawValues.OrderBy;
+            if (!string.IsNullOrEmpty(orderByString))
+            {
+                var orderByClauses = orderByString.Split(',').ToList();
+                var isThenBy = false;
+                orderByClauses.ForEach(obc => {
+                    var parts = obc.Trim().Replace("  ", " ").Split(' ');
+                    var propertyPath = parts[0];
+                    bool isDesc = parts.Length > 1 && parts[1] == "desc";
+                    var odi = new OrderByClause.OrderByItem(parts[0], isDesc);
+
+                    var func = QueryBuilder.BuildOrderByFunc(isThenBy, elementType, odi);
+                    result = func(result);
+                    isThenBy = true;
+                });
+            }
+
+            var skipQueryString = queryOptions.RawValues.Skip;
+            if (!string.IsNullOrWhiteSpace(skipQueryString))
+            {
+                var count = int.Parse(skipQueryString);
+                var method = TypeFns.GetMethodByExample((IQueryable<String> q) => Queryable.Skip<String>(q, 999), elementType);
+                var func = BuildIQueryableFunc(elementType, method, count);
+                result = func(result);
+            }
+
+            var topQueryString = queryOptions.RawValues.Top;
+            if (!string.IsNullOrWhiteSpace(topQueryString))
+            {
+                var count = int.Parse(topQueryString);
+                var method = TypeFns.GetMethodByExample((IQueryable<String> q) => Queryable.Take<String>(q, 999), elementType);
+                var func = BuildIQueryableFunc(elementType, method, count);
+                result = func(result);
+            }
+
+            return result;
+        }
+
+        private static Func<IQueryable, IQueryable> BuildIQueryableFunc<TArg>(Type instanceType, MethodInfo method, TArg parameter, Type queryableBaseType = null)
+        {
+            if (queryableBaseType == null)
+            {
+                queryableBaseType = typeof(IQueryable<>);
+            }
+            var paramExpr = Expression.Parameter(typeof(IQueryable));
+            var queryableType = queryableBaseType.MakeGenericType(instanceType);
+            var castParamExpr = Expression.Convert(paramExpr, queryableType);
+
+            var callExpr = Expression.Call(method, castParamExpr, Expression.Constant(parameter));
+            var castResultExpr = Expression.Convert(callExpr, typeof(IQueryable));
+            var lambda = Expression.Lambda(castResultExpr, paramExpr);
+            var func = (Func<IQueryable, IQueryable>)lambda.Compile();
+            return func;
+        }
+
+
+
+
+        /// <summary>
+        /// Perform any work after the query is executed.  Does nothing in this implementation but is available to derived classes.
+        /// </summary>
+        /// <param name="queryResult"></param>
+        /// <returns></returns>
+        public virtual IEnumerable PostExecuteQuery(IEnumerable queryResult)
+        {
+            return queryResult;
+        }
+
+        /// <summary>
+        /// Replaces the response.Content with the query results, wrapped in a QueryResult object if necessary.
+        /// </summary>
+        /// <param name="request"></param>
+        /// <param name="response"></param>
+        /// <param name="responseObject"></param>
+        /// <param name="queryable"></param>
+        public virtual void WrapResult(HttpRequest request, ActionExecutedContext actionExecutedContext, IQueryable queryResult)
+        {
+            Object tmp;
+            request.HttpContext.Items.TryGetValue("MS_InlineCount", out tmp);
+            var inlineCount = (Int64?)tmp;
+
+            // if a select or expand was encountered we need to
+            // execute the DbQueries here, so that any exceptions thrown can be properly returned.
+            // if we wait to have the query executed within the serializer, some exceptions will not
+            // serialize properly.
+
+            var listQueryResult = Enumerable.ToList((dynamic)queryResult);
+
+            var elementType = queryResult.ElementType;
+            if (elementType.Name.StartsWith("SelectAllAndExpand"))
+            {
+                var prop = elementType.GetProperties().FirstOrDefault(pi => pi.Name == "Instance");
+                var mi = prop.GetGetMethod();
+                var lqr = (List<Object>)listQueryResult;
+                listQueryResult = (dynamic)lqr.Select(item => {
+                    var instance = mi.Invoke(item, null);
+                    return (Object)instance;
+                }).ToList();
+            }
+
+            // HierarchyNodeExpressionVisitor
+            listQueryResult = PostExecuteQuery((IEnumerable)listQueryResult);
+
+            if (listQueryResult != null || inlineCount.HasValue)
+            {
+                Object result = listQueryResult;
+                if (inlineCount.HasValue)
+                {
+                    result = new QueryResult() { Results = listQueryResult, InlineCount = inlineCount };
+                }
+                var objResult = actionExecutedContext.Result as ObjectResult;
+                if (objResult != null && objResult.Value != null)
+                {
+                    var resultType = objResult.Value.GetType();
+                    if (resultType.Name != "String")
+                    {
+                        var ss = new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore };
+                        ss = JsonSerializationFns.UpdateWithDefaults(ss);
+                        //ss.TypeNameHandling = TypeNameHandling.None;
+                        //ss.PreserveReferencesHandling = PreserveReferencesHandling.None;
+                        //var finalJsonIndented = JsonConvert.SerializeObject(result, Formatting.Indented, ss);
+                        var jsonResult = new JsonResult(result, ss);
+                        actionExecutedContext.Result = jsonResult;
+                        //var oc = new ObjectContent(result.GetType(), result, formatter);
+                        //var oc = new ObjectResult(result.GetType(), result);
+                        //response.Content = oc;
+                        //actionExecutedContext.Result = 
+                        //actionExecutedContext.HttpContext.Response.con
+                    }
+                }
+            }
+        }
+
+
+        /// <summary>
+        /// Configure the JsonFormatter.  Does nothing in this implementation but is available to derived classes.
+        /// </summary>
+        /// <param name="request">Used to retrieve the current JsonFormatter</param>
+        /// <param name="queryable">Used to obtain the ISession</param>
+        public virtual void ConfigureFormatter(ActionExecutedContext actionExecutedContext, IQueryable queryable)
+        {
+            var controller = actionExecutedContext.Controller as Microsoft.AspNetCore.Mvc.Controller;
+            var formatSelector = actionExecutedContext.HttpContext.RequestServices.GetRequiredService<Microsoft.AspNetCore.Mvc.Infrastructure.OutputFormatterSelector>();
+            
+            //var jsonFormatter = request.GetConfiguration().Formatters.JsonFormatter;
+            //ConfigureFormatter(jsonFormatter, queryable);
+        }
+
+        /// <summary>
+        /// Configure the JsonFormatter.  Does nothing in this implementation but is available to derived classes.
+        /// </summary>
+        /// <param name="jsonFormatter"></param>
+        /// <param name="queryable">Used to obtain the ISession</param>
+        //public virtual void ConfigureFormatter(JsonMediaTypeFormatter jsonFormatter, IQueryable queryable)
+        //{
+        //}
+
+        /// <summary>
+        /// Release any resources associated with this QueryHelper.
+        /// </summary>
+        /// <param name="responseObject">Response payload, which may have associated resources.</param>
+        public virtual void Close(object responseObject)
+        {
+        }
+
+    }
+
+    /// <summary>
+    /// Wrapper for results that have an InlineCount, to support paged result sets.
+    /// </summary>
+    public class QueryResult
+    {
+        public dynamic Results { get; set; }
+        public Int64? InlineCount { get; set; }
+    }
+}

--- a/AspNetCore/Breeze.Core/Breeze.Core.csproj
+++ b/AspNetCore/Breeze.Core/Breeze.Core.csproj
@@ -28,7 +28,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="System.Linq.Queryable" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
     <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.1" />

--- a/AspNetCore/Breeze.Core/Query/QueryBuilder.cs
+++ b/AspNetCore/Breeze.Core/Query/QueryBuilder.cs
@@ -1,138 +1,161 @@
-﻿
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 
 
-namespace Breeze.Core {
+namespace Breeze.Core
+{
 
-  /// <summary>
-  /// Used to build up a Queryable.
-  /// </summary>
-  /// <remarks>
-  /// </remarks>
-  public class QueryBuilder {
+    /// <summary>
+    /// Used to build up a Queryable.
+    /// </summary>
+    /// <remarks>
+    /// </remarks>
+    public class QueryBuilder
+    {
 
-    public static IQueryable ApplyWhere(IQueryable source, Type elementType, BasePredicate predicate) {
-      var method = TypeFns.GetMethodByExample((IQueryable<String> q) => q.Where(s => s != null), elementType);
-      var lambdaExpr = predicate.ToLambda(elementType);
-      var func = BuildIQueryableFunc(elementType, method, lambdaExpr);
-      return func(source);
-    }
-
-
-
-    public static IQueryable ApplySelect(IQueryable source, Type elementType, SelectClause selectClause) {
-      var propSigs = selectClause.Properties;
-      var dti = DynamicTypeInfo.FindOrCreate(propSigs.Select(ps => ps.Name), propSigs.Select(ps => ps.ReturnType));
-      var lambdaExpr = CreateNewLambda(dti, propSigs);
-      var method = TypeFns.GetMethodByExample((IQueryable<String> q) => q.Select(s => s.Length), elementType, dti.DynamicType);
-      var func = BuildIQueryableFunc(elementType, method, lambdaExpr);
-      return func(source);
-    }
-
-    public static IQueryable ApplyOrderBy(IQueryable source, Type elementType, OrderByClause orderByClause) {
-      var orderByItems = orderByClause.OrderByItems;
-      var isThenBy = false;
-      orderByItems.ToList().ForEach(obi => {
-        var funcOb = QueryBuilder.BuildOrderByFunc(isThenBy, elementType, obi);
-        source = funcOb(source);
-        isThenBy = true;
-      });
-      return source;
-    }
-
-    public static IQueryable ApplySkip(IQueryable source, Type elementType, int skipCount) {
-      var method = TypeFns.GetMethodByExample((IQueryable<String> q) => Queryable.Skip<String>(q, 999), elementType);
-      var func = BuildIQueryableFunc(elementType, method, skipCount);
-      return func(source);
-    }
-
-    public static IQueryable ApplyTake(IQueryable source, Type elementType, int takeCount) {
-      var method = TypeFns.GetMethodByExample((IQueryable<String> q) => Queryable.Take<String>(q, 999), elementType);
-      var func = BuildIQueryableFunc(elementType, method, takeCount);
-      return func(source);
-    }
-
-    // TODO: Check if the ThenBy portion of this works
-    private static Func<IQueryable, IQueryable> BuildOrderByFunc(bool isThenBy, Type elementType, OrderByClause.OrderByItem obi) {
-      var propertyPath = obi.PropertyPath;
-      bool isDesc = obi.IsDesc;
-      var paramExpr = Expression.Parameter(elementType, "o");
-      Expression nextExpr = paramExpr;
-      var propertyNames = propertyPath.Split('.').ToList();
-      propertyNames.ForEach(pn => {
-        var nextElementType = nextExpr.Type;
-        var propertyInfo = nextElementType.GetTypeInfo().GetProperty(pn);
-        if (propertyInfo == null) {
-          throw new Exception("Unable to locate property: " + pn + " on type: " + nextElementType.ToString());
+        public static IQueryable ApplyWhere(IQueryable source, Type elementType, BasePredicate predicate)
+        {
+            var method = TypeFns.GetMethodByExample((IQueryable<String> q) => q.Where(s => s != null), elementType);
+            var lambdaExpr = predicate.ToLambda(elementType);
+            var func = BuildIQueryableFunc(elementType, method, lambdaExpr);
+            return func(source);
         }
-        nextExpr = Expression.MakeMemberAccess(nextExpr, propertyInfo);
-      });
-      var lambdaExpr = Expression.Lambda(nextExpr, paramExpr);
 
-      var orderByMethod = GetOrderByMethod(isThenBy, isDesc, elementType, nextExpr.Type);
 
-      var baseType = isThenBy ? typeof(IOrderedQueryable<>) : typeof(IQueryable<>);
-      var func = BuildIQueryableFunc(elementType, orderByMethod, lambdaExpr, baseType);
-      return func;
+
+        public static IQueryable ApplySelect(IQueryable source, Type elementType, SelectClause selectClause)
+        {
+            var propSigs = selectClause.Properties;
+            var dti = DynamicTypeInfo.FindOrCreate(propSigs.Select(ps => ps.Name), propSigs.Select(ps => ps.ReturnType));
+            var lambdaExpr = CreateNewLambda(dti, propSigs);
+            var method = TypeFns.GetMethodByExample((IQueryable<String> q) => q.Select(s => s.Length), elementType, dti.DynamicType);
+            var func = BuildIQueryableFunc(elementType, method, lambdaExpr);
+            return func(source);
+        }
+
+        public static Func<IQueryable, IQueryable> BuildSelectFunc(Type elementType, List<String> selectClauses)
+        {
+            var propSigs = selectClauses.Select(sc => new PropertySignature(elementType, sc)).ToList();
+            var dti = DynamicTypeInfo.FindOrCreate(propSigs.Select(ps => ps.Name), propSigs.Select(ps => ps.ReturnType));
+            var lambdaExpr = CreateNewLambda(dti, propSigs);
+            var method = TypeFns.GetMethodByExample((IQueryable<String> q) => q.Select(s => s.Length), elementType, dti.DynamicType);
+            var func = BuildIQueryableFunc(elementType, method, lambdaExpr);
+            return func;
+        }
+
+        public static IQueryable ApplyOrderBy(IQueryable source, Type elementType, OrderByClause orderByClause)
+        {
+            var orderByItems = orderByClause.OrderByItems;
+            var isThenBy = false;
+            orderByItems.ToList().ForEach(obi => {
+                var funcOb = QueryBuilder.BuildOrderByFunc(isThenBy, elementType, obi);
+                source = funcOb(source);
+                isThenBy = true;
+            });
+            return source;
+        }
+
+        public static IQueryable ApplySkip(IQueryable source, Type elementType, int skipCount)
+        {
+            var method = TypeFns.GetMethodByExample((IQueryable<String> q) => Queryable.Skip<String>(q, 999), elementType);
+            var func = BuildIQueryableFunc(elementType, method, skipCount);
+            return func(source);
+        }
+
+        public static IQueryable ApplyTake(IQueryable source, Type elementType, int takeCount)
+        {
+            var method = TypeFns.GetMethodByExample((IQueryable<String> q) => Queryable.Take<String>(q, 999), elementType);
+            var func = BuildIQueryableFunc(elementType, method, takeCount);
+            return func(source);
+        }
+
+        // TODO: Check if the ThenBy portion of this works
+        public static Func<IQueryable, IQueryable> BuildOrderByFunc(bool isThenBy, Type elementType, OrderByClause.OrderByItem obi)
+        {
+            var propertyPath = obi.PropertyPath;
+            bool isDesc = obi.IsDesc;
+            var paramExpr = Expression.Parameter(elementType, "o");
+            Expression nextExpr = paramExpr;
+            var propertyNames = propertyPath.Split('/').ToList();
+            propertyNames.ForEach(pn => {
+                var nextElementType = nextExpr.Type;
+                var propertyInfo = nextElementType.GetTypeInfo().GetProperty(pn);
+                if (propertyInfo == null)
+                {
+                    throw new Exception("Unable to locate property: " + pn + " on type: " + nextElementType.ToString());
+                }
+                nextExpr = Expression.MakeMemberAccess(nextExpr, propertyInfo);
+            });
+            var lambdaExpr = Expression.Lambda(nextExpr, paramExpr);
+
+            var orderByMethod = GetOrderByMethod(isThenBy, isDesc, elementType, nextExpr.Type);
+
+            var baseType = isThenBy ? typeof(IOrderedQueryable<>) : typeof(IQueryable<>);
+            var func = BuildIQueryableFunc(elementType, orderByMethod, lambdaExpr, baseType);
+            return func;
+        }
+
+
+
+        private static MethodInfo GetOrderByMethod(bool isThenBy, bool isDesc, Type elementType, Type nextExprType)
+        {
+            MethodInfo orderByMethod;
+            if (isThenBy)
+            {
+                orderByMethod = isDesc
+                                  ? TypeFns.GetMethodByExample(
+                                    (IOrderedQueryable<String> q) => q.ThenByDescending(s => s.Length),
+                                    elementType, nextExprType)
+                                  : TypeFns.GetMethodByExample(
+                                    (IOrderedQueryable<String> q) => q.ThenBy(s => s.Length),
+                                    elementType, nextExprType);
+            }
+            else
+            {
+                orderByMethod = isDesc
+                                  ? TypeFns.GetMethodByExample(
+                                    (IQueryable<String> q) => q.OrderByDescending(s => s.Length),
+                                    elementType, nextExprType)
+                                  : TypeFns.GetMethodByExample(
+                                    (IQueryable<String> q) => q.OrderBy(s => s.Length),
+                                    elementType, nextExprType);
+            }
+            return orderByMethod;
+        }
+
+        private static LambdaExpression CreateNewLambda(DynamicTypeInfo dti, IEnumerable<PropertySignature> selectors)
+        {
+            var paramExpr = Expression.Parameter(selectors.First().InstanceType, "t");
+            // cannot create a NewExpression on a dynamic type becasue of EF restrictions
+            // so we always create a MemberInitExpression with bindings ( i.e. a new Foo() { a=1, b=2 } instead of new Foo(1,2);
+            var newExpr = Expression.New(dti.DynamicEmptyConstructor);
+            var propertyExprs = selectors.Select(s => s.BuildMemberExpression(paramExpr));
+            var dynamicProperties = dti.DynamicType.GetTypeInfo().GetProperties();
+            var bindings = dynamicProperties.Zip(propertyExprs, (prop, expr) => Expression.Bind(prop, expr));
+            var memberInitExpr = Expression.MemberInit(newExpr, bindings.Cast<MemberBinding>());
+            var newLambda = Expression.Lambda(memberInitExpr, paramExpr);
+            return newLambda;
+        }
+
+        public static Func<IQueryable, IQueryable> BuildIQueryableFunc<TArg>(Type instanceType, MethodInfo method, TArg parameter, Type queryableBaseType = null)
+        {
+            if (queryableBaseType == null)
+            {
+                queryableBaseType = typeof(IQueryable<>);
+            }
+            var paramExpr = Expression.Parameter(typeof(IQueryable));
+            var queryableType = queryableBaseType.MakeGenericType(instanceType);
+            var castParamExpr = Expression.Convert(paramExpr, queryableType);
+
+
+            var callExpr = Expression.Call(method, castParamExpr, Expression.Constant(parameter));
+            var castResultExpr = Expression.Convert(callExpr, typeof(IQueryable));
+            var lambda = Expression.Lambda(castResultExpr, paramExpr);
+            var func = (Func<IQueryable, IQueryable>)lambda.Compile();
+            return func;
+        }
     }
-
-
-
-    private static MethodInfo GetOrderByMethod(bool isThenBy, bool isDesc, Type elementType, Type nextExprType) {
-      MethodInfo orderByMethod;
-      if (isThenBy) {
-        orderByMethod = isDesc
-                          ? TypeFns.GetMethodByExample(
-                            (IOrderedQueryable<String> q) => q.ThenByDescending(s => s.Length),
-                            elementType, nextExprType)
-                          : TypeFns.GetMethodByExample(
-                            (IOrderedQueryable<String> q) => q.ThenBy(s => s.Length),
-                            elementType, nextExprType);
-      } else {
-        orderByMethod = isDesc
-                          ? TypeFns.GetMethodByExample(
-                            (IQueryable<String> q) => q.OrderByDescending(s => s.Length),
-                            elementType, nextExprType)
-                          : TypeFns.GetMethodByExample(
-                            (IQueryable<String> q) => q.OrderBy(s => s.Length),
-                            elementType, nextExprType);
-      }
-      return orderByMethod;
-    }
-
-    private static LambdaExpression CreateNewLambda(DynamicTypeInfo dti, IEnumerable<PropertySignature> selectors) {
-      var paramExpr = Expression.Parameter(selectors.First().InstanceType, "t");
-      // cannot create a NewExpression on a dynamic type becasue of EF restrictions
-      // so we always create a MemberInitExpression with bindings ( i.e. a new Foo() { a=1, b=2 } instead of new Foo(1,2);
-      var newExpr = Expression.New(dti.DynamicEmptyConstructor);
-      var propertyExprs = selectors.Select(s => s.BuildMemberExpression(paramExpr));
-      var dynamicProperties = dti.DynamicType.GetTypeInfo().GetProperties();
-      var bindings = dynamicProperties.Zip(propertyExprs, (prop, expr) => Expression.Bind(prop, expr));
-      var memberInitExpr = Expression.MemberInit(newExpr, bindings.Cast<MemberBinding>());
-      var newLambda = Expression.Lambda(memberInitExpr, paramExpr);
-      return newLambda;
-    }
-
-    public static Func<IQueryable, IQueryable> BuildIQueryableFunc<TArg>(Type instanceType, MethodInfo method, TArg parameter, Type queryableBaseType = null) {
-      if (queryableBaseType == null) {
-        queryableBaseType = typeof(IQueryable<>);
-      }
-      var paramExpr = Expression.Parameter(typeof(IQueryable));
-      var queryableType = queryableBaseType.MakeGenericType(instanceType);
-      var castParamExpr = Expression.Convert(paramExpr, queryableType);
-
-
-      var callExpr = Expression.Call(method, castParamExpr, Expression.Constant(parameter));
-      var castResultExpr = Expression.Convert(callExpr, typeof(IQueryable));
-      var lambda = Expression.Lambda(castResultExpr, paramExpr);
-      var func = (Func<IQueryable, IQueryable>)lambda.Compile();
-      return func;
-    }
-  }
 }
-    

--- a/AspNetCore/Breeze.Persistence.EFCore/Breeze.Persistence.EFCore.csproj
+++ b/AspNetCore/Breeze.Persistence.EFCore/Breeze.Persistence.EFCore.csproj
@@ -28,7 +28,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AspNetCore/Breeze.Persistence.EFCore/MetadataBuilder_EFC2.cs
+++ b/AspNetCore/Breeze.Persistence.EFCore/MetadataBuilder_EFC2.cs
@@ -1,0 +1,447 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+using System.Linq;
+using Newtonsoft.Json;
+using System.Dynamic;
+using System.Reflection;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Linq;
+using Breeze.Core;
+using System.ComponentModel.DataAnnotations;
+
+namespace Breeze.Persistence.EFCore
+{
+    public static class MetadataBuilder_EFC2
+    {
+        public static String GetMetadataFromContext(DbContext context)
+        {
+            return GetMetadataFromDbContext(context);
+        }
+
+        private static String GetMetadataFromDbContext(DbContext dbContext)
+        {
+            var entTypes = dbContext.Model.GetEntityTypes().OrderBy(et => et.Name).ToList();
+            var associationList = new List<string>();
+            var enums = new List<Type>();
+            #region Init
+            Func<string, string> className = fullClassName =>
+            {
+                return fullClassName.Split('.').Last();
+            };
+            var nameSpace = className(entTypes.First().ClrType.Namespace);
+            var entityContainerName = className(dbContext.GetType().FullName);
+
+            var uniqueRoleNames = new Dictionary<ValueTuple<string, string>, ValueTuple<List<ValueTuple<INavigation, string>>, Int32>>();
+            Func<INavigation, string> getRoleName = nav =>
+            {
+                var principalType = className(nav.DeclaringEntityType.Name);
+                var dependentType = className(nav.FindInverse()?.DeclaringEntityType?.Name);
+                if (principalType != dependentType /*|| principalType != "BusinessEntity"*/)
+                    return principalType;
+                var key = (principalType, dependentType);
+                if (!uniqueRoleNames.ContainsKey(key))
+                {
+                    var roleName = principalType;
+                    uniqueRoleNames.Add(key, (new List<ValueTuple<INavigation, string>> { (nav, roleName) }, 0));
+                    return roleName;
+                }
+                else
+                {
+                    var curRoleNames = uniqueRoleNames[key];
+                    var curRoleName = curRoleNames.Item1.FirstOrDefault(n => n.Item1 == nav);
+                    if (curRoleName.Item1 == nav)
+                        return curRoleName.Item2;
+                    curRoleNames = (curRoleNames.Item1, curRoleNames.Item2 + 1);
+                    uniqueRoleNames[key] = curRoleNames;
+                    var roleName = principalType + curRoleNames.Item2.ToString();
+                    curRoleNames.Item1.Add((nav, roleName));
+                    return roleName;
+                }
+            };
+
+            try
+            {
+                var metaInit = $@"
+            {{
+                ""schema"": {{
+			        ""xmlns:annotation"": ""http://schemas.microsoft.com/ado/2009/02/edm/annotation"",
+                    ""xmlns:p1"": ""http://schemas.microsoft.com/ado/2009/02/edm/annotation"",
+                    ""xmlns"": ""http://schemas.microsoft.com/ado/2009/11/edm"",
+                    ""namespace"": ""{nameSpace}"",
+                    ""alias"": ""Self"",
+                    ""p1:UseStrongSpatialTypes"": ""false""
+                }}
+			}}
+			";
+
+                var converter = new ExpandoObjectConverter();
+                dynamic meta = JsonConvert.DeserializeObject<ExpandoObject>(metaInit, converter);
+                #endregion
+
+                #region cSpaceOSpaceMapping
+                string cSpaceOSpaceMapping = "[";
+                entTypes.ForEach(et => cSpaceOSpaceMapping += $@"[""{nameSpace}.{className(et.Name)}"",""{et.Name}""],");
+                cSpaceOSpaceMapping = cSpaceOSpaceMapping.TrimEnd(',') + "]";
+                meta.schema.cSpaceOSpaceMapping = cSpaceOSpaceMapping;
+                #endregion
+
+                #region entityContainer
+                dynamic entityContainer = new ExpandoObject();
+                meta.schema.entityContainer = entityContainer;
+                entityContainer.name = entityContainerName;
+                var entityContainerDict = entityContainer as IDictionary<string, Object>;
+                entityContainerDict.Add("p1:LazyLoadingEnabled", "false");
+
+                #region entitySet
+                var entitySet = new List<object>();
+                entityContainer.entitySet = entitySet;
+                entTypes.ForEach(et =>
+                {
+                    dynamic entityProp = new ExpandoObject();
+                    entityProp.name = className(et.Name);
+                    entityProp.entityType = nameSpace + "." + className(et.Name);
+                    entitySet.Add(entityProp);
+                });
+                #endregion
+
+                #region associationSet
+                var associations = new List<object>();
+                meta.schema.association = associations;
+
+                var associationSet = new List<object>();
+                entityContainer.associationSet = associationSet;
+                entTypes.ForEach(entType =>
+                {
+                    var navs = entType.GetNavigations().ToList();
+                    navs.ForEach(nav =>
+                    {
+                        var inverse = nav.FindInverse();
+                        if (inverse == null)
+                            return;
+                        var properNav = nav.IsDependentToPrincipal() ? inverse : nav;
+                        if (properNav == null)
+                            properNav = nav;
+                        var properInvNav = properNav.FindInverse();
+                        if (properInvNav == null)
+                            properInvNav = properNav;
+                        var associationName = "FK_" + className(properInvNav.DeclaringEntityType.Name) + "_" + properInvNav.Name;
+                        dynamic navProp = new ExpandoObject();
+                        dynamic assProp = new ExpandoObject();
+                        associationSet.Add(navProp);
+                        //if (associationName == "FK_EquipmentEvent_User" || associationName == "FK_EquipmentEvent_AddedByUser")
+                        //{
+                        //    associationName = associationName;
+                        //}
+                        //if (associationName == "FK_EquipmentEvent_AddedByEquipmentEvent")
+                        //{
+                        //    associationName = associationName;
+                        //}
+                        var assAdded = false;
+                        if (!associationList.Contains(associationName))
+                        {
+                            associations.Add(assProp);
+                            associationList.Add(associationName);
+                            assAdded = true;
+                        }
+                        navProp.name = associationName;
+                        navProp.association = nameSpace + "." + associationName;
+                        var end = new List<object>();
+                        navProp.end = end;
+                        dynamic endProp0 = new ExpandoObject();
+                        dynamic endProp1 = new ExpandoObject();
+                        end.Add(endProp0);
+                        end.Add(endProp1);
+                        //endProp0.role = className(properNav.DeclaringEntityType.Name);
+                        endProp0.role = getRoleName(properNav);
+                        endProp0.entitySet = className(properNav.DeclaringEntityType.Name);
+                        //endProp1.role = className(properInvNav.DeclaringEntityType.Name);
+                        endProp1.role = getRoleName(properInvNav);
+                        endProp1.entitySet = className(properInvNav.DeclaringEntityType.Name);
+
+                        assProp.name = associationName;
+                        var assEnds = new List<object>();
+                        assProp.end = assEnds;
+
+                        dynamic assEndProp0 = new ExpandoObject();
+                        assEnds.Add(assEndProp0);
+                        assEndProp0.type = "Edm." + nameSpace + "." + endProp0.entitySet;
+                        assEndProp0.role = endProp0.role;
+                        assEndProp0.multiplicity = "1";
+
+                        dynamic assEndProp1 = new ExpandoObject();
+                        assEnds.Add(assEndProp1);
+                        assEndProp1.type = "Edm." + nameSpace + "." + endProp1.entitySet;
+                        assEndProp1.role = endProp1.role;
+                        assEndProp1.multiplicity = properNav.IsCollection() ? "*" : "1" ;
+
+                        dynamic referentialConstraint = new ExpandoObject();
+                        assProp.referentialConstraint = referentialConstraint;
+                        dynamic principal = new ExpandoObject();
+                        dynamic dependent = new ExpandoObject();
+                        principal.role = assEndProp0.role;
+                        dependent.role = assEndProp1.role;
+                        referentialConstraint.principal = principal;
+                        referentialConstraint.dependent = dependent;
+
+                        //if (associationName == "FK_EquipmentEvent_AddedByUser")
+                        //{
+                        //    associationName = associationName;
+                        //}
+                        //if (associationName == "FK_CustomerContractXref_Circuit")
+                        //{
+                        //    associationName = associationName;
+                        //}
+
+                        var pkNames = properNav.ForeignKey.PrincipalKey.Properties.Select(p => p.Name);
+                        if (pkNames.Count() == 1)
+                        {
+                            principal.propertyRef = new ExpandoObject();
+                            principal.propertyRef.name = pkNames.FirstOrDefault();
+                        }
+                        else
+                        {
+                            var propertyRefs = new List<object>();
+                            principal.propertyRef = propertyRefs;
+                            pkNames.ToList().ForEach(fkName =>
+                            {
+                                dynamic propertyRef = new ExpandoObject();
+                                propertyRef.name = fkName;
+                                propertyRefs.Add(propertyRef);
+                            });
+                        }
+
+                        var isNullableFK = properNav.ForeignKey.Properties.Count(k => k.IsColumnNullable());
+                        if (isNullableFK > 0)
+                            assEndProp0.multiplicity = "0..1";
+
+                        var fkNames = properNav.ForeignKey.Properties.Select(p => p.Name);
+                        if (fkNames.Count() == 1)
+                        {
+                            dependent.propertyRef = new ExpandoObject();
+                            dependent.propertyRef.name = fkNames.FirstOrDefault();
+                        }
+                        else
+                        {
+                            var propertyRefs = new List<object>();
+                            dependent.propertyRef = propertyRefs;
+                            fkNames.ToList().ForEach(fkName =>
+                            {
+                                dynamic propertyRef = new ExpandoObject();
+                                propertyRef.name = fkName;
+                                propertyRefs.Add(propertyRef);
+                            });
+                        }
+
+                    });
+                });
+                #endregion
+                
+                #endregion
+
+
+                #region entityType
+                    var entityTypes = new List<object>();
+                    meta.schema.entityType = entityTypes;
+                    entTypes.ForEach(entType =>
+                    {
+                        dynamic entityType = new ExpandoObject();
+                        entityTypes.Add(entityType);
+                        entityType.name = className(entType.Name);
+                        dynamic keys = new ExpandoObject();
+                        entityType.key = keys;
+                        var entKeys = entType.GetProperties().Where(p => p.IsPrimaryKey()).ToList();
+                        if (entKeys.Count == 1)
+                        {
+                            dynamic propertyRef = new ExpandoObject();
+                            keys.propertyRef = propertyRef;
+                            propertyRef.name = entKeys.First().Name;
+                        }
+                        else
+                        {
+                            var propertyRef = new List<object>();
+                            keys.propertyRef = propertyRef;
+                            entKeys.ForEach(key =>
+                            {
+                                dynamic keyProp = new ExpandoObject();
+                                propertyRef.Add(keyProp);
+                                keyProp.name = key.Name;
+                            });
+                        }
+
+                        var properties = new List<object>();
+                        entityType.property = properties;
+                        entType.GetProperties().ToList().ForEach(p =>
+                        {
+                            dynamic fieldProp = new ExpandoObject();
+                            properties.Add(fieldProp);
+                            fieldProp.name = p.Name;
+                            fieldProp.type = NormalizeDataTypeName(p.ClrType);
+                            if (fieldProp.type == "Edm.String")
+                            {
+                                fieldProp.unicode = "true";
+                                fieldProp.fixedLength = "false";
+                            }
+                            if (p.GetMaxLength().HasValue)
+                            {
+                                if (p.GetMaxLength().Value == Int32.MaxValue)
+                                    fieldProp.maxLength = "Max";
+                                else
+                                    fieldProp.maxLength = p.GetMaxLength().ToString();
+                            }
+                            if (fieldProp.type == "Edm.Byte")
+                            {
+                                fieldProp.type = "Edm.Binary";
+                                //p.ClrType.IsArray
+                                //result == "Edm.Byte[]")
+                                var minLengthA = p.GetAnnotations().Where(a => a.Name == "MinLength").FirstOrDefault();
+                                if (minLengthA != null)
+                                    fieldProp.fixedLength = (int)minLengthA.Value == p.GetMaxLength() ? "true": "false";
+                            }
+
+                            if (p.ClrType.IsEnum && !enums.Contains(p.ClrType))
+                                enums.Add(p.ClrType);
+
+                            var stringLengthA = p.GetAnnotations().Where(a => a.Name == "StringLength").FirstOrDefault();
+                            if (stringLengthA != null) {
+                                var stringLen = stringLengthA as StringLengthAttribute;
+                                if (stringLen != null)
+                                {
+                                    if (stringLen.MinimumLength == stringLen.MaximumLength)
+                                        fieldProp.fixedLength = "true";
+                                    if (!p.GetMaxLength().HasValue)
+                                        fieldProp.maxLength = stringLen.MaximumLength.ToString();
+                                }
+                            }
+                            var reqA = p.GetAnnotations().Where(a => a.Name == "Required").FirstOrDefault();
+                            if (reqA != null || !p.IsNullable)
+                                fieldProp.nullable = "false";
+                            if (p.IsPrimaryKey() && p.ValueGenerated == ValueGenerated.OnAdd)
+                                (fieldProp as IDictionary<string, object>)["p1:StoreGeneratedPattern"] = "Identity";
+                            
+                            
+                            if (p.ValueGenerated == ValueGenerated.OnAddOrUpdate)
+                                (fieldProp as IDictionary<string, object>)["p1:StoreGeneratedPattern"] = "Computed";
+                            if (p.IsUnicode().HasValue && p.IsUnicode().Value)
+                                fieldProp.unicode = "true";
+
+                            if (entityType.name == "CircuitView" && p.Name == "Id")
+                            {
+                                Console.WriteLine("");
+                            }
+                        });
+
+                        var navigationProperties = new List<object>();
+                        entityType.navigationProperty = navigationProperties;
+                        var navs = entType.GetNavigations().ToList();
+                        navs.ForEach(nav =>
+                        {
+                            var inverse = nav.FindInverse();
+                            if (inverse == null)
+                                return;
+                            var properNav = nav.IsDependentToPrincipal() ? inverse : nav;
+                            if (properNav == null)
+                                properNav = nav;
+                            var properInvNav = properNav.FindInverse();
+                            if (properInvNav == null)
+                                properInvNav = properNav;
+                            
+                            var associationName = "FK_" + className(properInvNav.DeclaringEntityType.Name) + "_" + properInvNav.Name;
+                            dynamic navProp = new ExpandoObject();
+                            navigationProperties.Add(navProp);
+                            navProp.name = nav.Name;
+                            navProp.relationship = nameSpace + "." + associationName;
+                            navProp.fromRole = className(className(nav.DeclaringEntityType.Name));
+                            navProp.toRole = className(className(inverse.DeclaringEntityType.Name));
+                            navProp.fromRole = getRoleName(nav);
+                            navProp.toRole = getRoleName(inverse);
+                        });
+                    });
+
+                #endregion
+
+                #region enums
+                var enumTypes = new List<object>();
+                meta.schema.enumType = enumTypes;
+                enums.ForEach(enumItem =>
+                {
+                    dynamic enumType = new ExpandoObject();
+                    enumTypes.Add(enumType);
+                    enumType.name = className(enumItem.Name);
+                    var members = new List<object>();
+                    enumType.member = members;
+                    foreach (var enumValue in Enum.GetValues(enumItem))
+                    {
+                        dynamic memberItem = new ExpandoObject();
+                        members.Add(memberItem);
+                        memberItem.name = enumValue.ToString();
+                        //memberItem.value = enumValue.GetHashCode().ToString();
+                        memberItem.value = Convert.ToInt32(enumValue).ToString();
+                    };
+                });
+                //
+                #endregion
+
+                var ss = new JsonSerializerSettings();
+                ss = JsonSerializationFns.UpdateWithDefaults(ss);
+                ss.TypeNameHandling = TypeNameHandling.None;
+                ss.PreserveReferencesHandling = PreserveReferencesHandling.None;
+                var finalJsonIndented = JsonConvert.SerializeObject(meta, Formatting.Indented, ss);
+                var finalJson = JsonConvert.SerializeObject(meta, Formatting.None, ss);
+                return finalJson;
+            }
+            catch (Exception ex)
+            {
+                throw ex;
+            }
+        }
+        private static string NormalizeDataTypeName(Type type)
+        {
+            type = TypeFns.GetNonNullableType(type);
+            var result = type.ToString().Replace("System.", "Edm.");
+            if (result == "Edm.Byte[]")
+            {
+                return "Edm.Binary";
+            }
+            else
+            {
+                return result;
+            }
+            return result;
+        }
+    }
+
+    public static class ExpandoHelpers
+    {
+        public static void AddProperty(this ExpandoObject expando, string propertyName, object propertyValue)
+        {
+            // ExpandoObject supports IDictionary so we can extend it like this
+            var expandoDict = expando as IDictionary<string, object>;
+            if (expandoDict.ContainsKey(propertyName))
+                expandoDict[propertyName] = propertyValue;
+            else
+                expandoDict.Add(propertyName, propertyValue);
+        }
+        public static bool IsValid(this ExpandoObject expando, string propertyName)
+        {
+            // Check that they supplied a name
+            if (string.IsNullOrWhiteSpace(propertyName))
+                return false;
+            // ExpandoObject supports IDictionary so we can extend it like this
+            var expandoDict = expando as IDictionary<string, object>;
+            return expandoDict.ContainsKey(propertyName);
+        }
+    }
+
+    public class BreezeMetadata
+    {
+        public string MetadataVersion { get; set; }
+        public string NamingConvention { get; set; }
+        public List<MetaType> StructuralTypes
+        {
+            get; set;
+        }
+    }
+}

--- a/AspNetCore/Breeze.Persistence/Breeze.Persistence.csproj
+++ b/AspNetCore/Breeze.Persistence/Breeze.Persistence.csproj
@@ -28,7 +28,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Entity FrameWork 2.2.  Odata rather than JSON.  MetaData is formatted in EF6 style.

```
[HttpGet]
        [Produces("text/plain")] // this will return the raw JSON without the quotes
        public IActionResult MetaData()
        {
            //var oldMeta = _contextProvider.Metadata();
            //return Ok(oldMeta);
            //dynamic parsedJson = Newtonsoft.Json.JsonConvert.DeserializeObject(oldMeta);
            //Newtonsoft.Json.JsonConvert.SerializeObject(parsedJson, Formatting.Indented);

            var metaDataString = Breeze.Persistence.EFCore.MetadataBuilder_EFC2.GetMetadataFromContext(_context);
            return Ok(metaDataString);
        }
```

Use EnableBreezeQuery  I.e.,
```
[Produces("application/json")]
    [Route("breeze/[controller]/[action]")]
    //[BreezeQueryFilter]
    [EnableBreezeQuery]
    public partial class MyController : ODataController
    {
```
