### PR TITLE
update to .net standard 2.1 and updating references to latest version…

### DIFF
--- a/AspNetCore/Breeze.AspNetCore.NetCore/Breeze.AspNetCore.NetCore.csproj
+++ b/AspNetCore/Breeze.AspNetCore.NetCore/Breeze.AspNetCore.NetCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <PackageId>Breeze.AspNetCore.NetCore</PackageId>
     <PackageVersion>0.0.2</PackageVersion>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>

--- a/AspNetCore/Breeze.Core/Breeze.Core.csproj
+++ b/AspNetCore/Breeze.Core/Breeze.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <PackageId>Breeze.Core</PackageId>
     <PackageVersion>0.0.2</PackageVersion>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
@@ -28,10 +28,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.6.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="System.Linq.Queryable" Version="4.3.0" />
-    <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.Emit" Version="4.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AspNetCore/Breeze.Core/DynamicGenericTypeBuilder.cs
+++ b/AspNetCore/Breeze.Core/DynamicGenericTypeBuilder.cs
@@ -17,315 +17,340 @@ using System.IO;
 // using System.Runtime.Serialization;
 
 
-namespace Breeze.Core {
+namespace Breeze.Core
+{
 
-  // This class is a hack because I can't get the IL Emit for Equals and GetHashCode to work in Silverlight becuase of a 
-  // VerificationException.  
-
-  /// <summary>
-  /// For internal use only.
-  /// </summary>
-  public abstract class DynamicTypeBase {
+    // This class is a hack because I can't get the IL Emit for Equals and GetHashCode to work in Silverlight becuase of a 
+    // VerificationException.  
 
     /// <summary>
     /// For internal use only.
     /// </summary>
-    public DynamicTypeBase() { }
+    public abstract class DynamicTypeBase
+    {
 
-    ///// <summary>
-    ///// 
-    ///// </summary>
-    ///// <param name="obj"></param>
-    ///// <returns></returns>
-    //public override bool Equals(object obj) {
+        /// <summary>
+        /// For internal use only.
+        /// </summary>
+        public DynamicTypeBase() { }
 
-    //  if (obj == null) return false;
-    //  if (obj.GetType() != this.GetType()) return false;
-    //  var deconstructFunc = GetDeconstructorFunc(this.GetType());
-    //  var theseItems = deconstructFunc(this);
-    //  var otherItems = deconstructFunc(obj);
-    //  return theseItems.SequenceEqual(otherItems);
-    //}
+        ///// <summary>
+        ///// 
+        ///// </summary>
+        ///// <param name="obj"></param>
+        ///// <returns></returns>
+        //public override bool Equals(object obj) {
 
-    ///// <summary>
-    ///// 
-    ///// </summary>
-    ///// <returns></returns>
-    //public override int GetHashCode() {
-    //  var deconstructFunc = GetDeconstructorFunc(this.GetType());
-    //  var otherItems = deconstructFunc(this);
-    //  return otherItems.GetAggregateHashCode();
-    //}
+        //  if (obj == null) return false;
+        //  if (obj.GetType() != this.GetType()) return false;
+        //  var deconstructFunc = GetDeconstructorFunc(this.GetType());
+        //  var theseItems = deconstructFunc(this);
+        //  var otherItems = deconstructFunc(obj);
+        //  return theseItems.SequenceEqual(otherItems);
+        //}
 
-    //private Func<Object, Object[]> GetDeconstructorFunc(Type type) {
+        ///// <summary>
+        ///// 
+        ///// </summary>
+        ///// <returns></returns>
+        //public override int GetHashCode() {
+        //  var deconstructFunc = GetDeconstructorFunc(this.GetType());
+        //  var otherItems = deconstructFunc(this);
+        //  return otherItems.GetAggregateHashCode();
+        //}
 
-    //  Func<Object, Object[]> func = null;
-    //  lock (__deconstructorMap) {
-    //    if ( !__deconstructorMap.TryGetValue(type, out func)) {
-    //      func = AnonymousFns.BuildDeconstructorFunc(type, false);
-    //      __deconstructorMap[type] = func;
-    //    }
-    //  }
-    //  return func;
-    //}
+        //private Func<Object, Object[]> GetDeconstructorFunc(Type type) {
 
-    //private static Dictionary<Type, Func<Object, Object[]>> __deconstructorMap = new Dictionary<Type,Func<object,object[]>>();
+        //  Func<Object, Object[]> func = null;
+        //  lock (__deconstructorMap) {
+        //    if ( !__deconstructorMap.TryGetValue(type, out func)) {
+        //      func = AnonymousFns.BuildDeconstructorFunc(type, false);
+        //      __deconstructorMap[type] = func;
+        //    }
+        //  }
+        //  return func;
+        //}
 
+        //private static Dictionary<Type, Func<Object, Object[]>> __deconstructorMap = new Dictionary<Type,Func<object,object[]>>();
 
-  }
-
-  internal static class DynamicGenericTypeBuilder {
-    /// <summary>
-    /// Constructs a new dynamic entity type from the specified DynamicTypeInfo.
-    /// </summary>
-    /// <param name="info">An DynamicTypeInfo instance</param>
-    /// <returns></returns>
-    /// <exception cref="ArgumentException">Thrown if the dynamic type key name is already defined.</exception>
-    public static Type CreateType(DynamicTypeInfo info) {
-      if (info == null) {
-        throw new ArgumentNullException("info");
-      }
-
-      AssemblyBuilder asmBuilder = BuildAssembly(info);
-      ModuleBuilder modBuilder = BuildModule(info, asmBuilder);
-      TypeBuilder typBuilder = BuildType(info, modBuilder);
-      var parameterBuilders = BuildGenericParameters(info, typBuilder);
-
-      // Build the fields
-      var fieldBuilders = BuildFields(info, typBuilder, parameterBuilders).ToList();
-
-      // Build an empty (parameterless) ctor
-      BuildEmptyCtor(info, typBuilder);
-      // Build a ctor that includes all properties.
-      BuildCtor(info, typBuilder, fieldBuilders, parameterBuilders);
-
-
-      // Build Properties
-      BuildProperties(info, typBuilder, fieldBuilders, parameterBuilders);
-
-      // BuildEqualsMethod(info, typBuilder, fieldBuilders);
-      // BuildGetHashCodeMethod(info, typBuilder, fieldBuilders);
-
-      // var openGenericType = typBuilder.CreateType();
-      var openGenericType = typBuilder.CreateTypeInfo();
-      var returnType = openGenericType.MakeGenericType(info.PropertyTypes.ToArray());
-      //OnDynamicEntityTypeCreated(new DynamicEntityTypeCreatedEventArgs(returnType));
-      //if (info.DynamicTypeShouldSave) {
-
-      //  asmBuilder.Save(asmBuilder.GetName().Name + ".dll");
-
-      //}
-
-      return returnType;
 
     }
 
-    private static AssemblyBuilder BuildAssembly(DynamicTypeInfo info) {
-      //AppDomain aDomain = Thread.GetDomain();
+    internal static class DynamicGenericTypeBuilder
+    {
+        /// <summary>
+        /// Constructs a new dynamic entity type from the specified DynamicTypeInfo.
+        /// </summary>
+        /// <param name="info">An DynamicTypeInfo instance</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentException">Thrown if the dynamic type key name is already defined.</exception>
+        public static Type CreateType(DynamicTypeInfo info)
+        {
+            if (info == null)
+            {
+                throw new ArgumentNullException("info");
+            }
 
-      //// Build the assembly
-      //AssemblyName asmName = new AssemblyName();
-      //asmName.Name = info.DynamicTypeName + DynamicTypeInfo.DynamicAssemblyNameSuffix;
-      //AssemblyBuilder asmBuilder;
+            AssemblyBuilder asmBuilder = BuildAssembly(info);
+            ModuleBuilder modBuilder = BuildModule(info, asmBuilder);
+            TypeBuilder typBuilder = BuildType(info, modBuilder);
+            var parameterBuilders = BuildGenericParameters(info, typBuilder);
 
-      //if (info.DynamicTypeShouldSave) {
-      //  if (String.IsNullOrEmpty(info.DynamicTypeFileDirectory)) {
-      //    asmBuilder = aDomain.DefineDynamicAssembly(asmName, AssemblyBuilderAccess.RunAndSave);
-      //  } else {
-      //    asmBuilder = aDomain.DefineDynamicAssembly(asmName, AssemblyBuilderAccess.RunAndSave, info.DynamicTypeFileDirectory);
-      //  }
-      //} else {
-      //  asmBuilder = aDomain.DefineDynamicAssembly(asmName, AssemblyBuilderAccess.Run);
-      //}
-      // return asmBuilder;
-      var asmName = info.DynamicTypeName + DynamicTypeInfo.DynamicAssemblyNameSuffix;
-      var asmBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName(asmName), AssemblyBuilderAccess.Run);
-      return asmBuilder;
-    }
+            // Build the fields
+            var fieldBuilders = BuildFields(info, typBuilder, parameterBuilders).ToList();
 
-    private static ModuleBuilder BuildModule(DynamicTypeInfo info, AssemblyBuilder asmBuilder) {
-      // Build the module
-      ModuleBuilder modBuilder;
+            // Build an empty (parameterless) ctor
+            BuildEmptyCtor(info, typBuilder);
+            // Build a ctor that includes all properties.
+            BuildCtor(info, typBuilder, fieldBuilders, parameterBuilders);
 
-      modBuilder = asmBuilder.DefineDynamicModule("DynamicAnonTypeModule_" + info.TypeName);
-      
-      return modBuilder;
-    }
 
-    private static TypeBuilder BuildType(DynamicTypeInfo info, ModuleBuilder modBuilder) {
-      // Build the type
-      var typBuilder = modBuilder.DefineType(info.DynamicTypeName,
-        TypeAttributes.Public |
-        TypeAttributes.Class |
-        TypeAttributes.AutoClass |
-        TypeAttributes.AnsiClass |
-        TypeAttributes.BeforeFieldInit |
-        TypeAttributes.AutoLayout,
-        // typeof(Object));
-        typeof(DynamicTypeBase));
-      return typBuilder;
-    }
+            // Build Properties
+            BuildProperties(info, typBuilder, fieldBuilders, parameterBuilders);
 
-    private static Type[] BuildGenericParameters(DynamicTypeInfo info, TypeBuilder typBuilder) {
-      // generates the names T0, T1, T2 ...
-      String[] parameterNames = Enumerable.Range(0, info.PropertyNames.Count).Select(i => "T" + i.ToString()).ToArray();
-      var parameterBuilders = typBuilder.DefineGenericParameters(parameterNames);
-      return parameterBuilders.Select(pb => pb.AsType()).ToArray();
-    }
+            // BuildEqualsMethod(info, typBuilder, fieldBuilders);
+            // BuildGetHashCodeMethod(info, typBuilder, fieldBuilders);
 
-    private static void BuildCtor(DynamicTypeInfo info, TypeBuilder typBuilder,
-      List<FieldBuilder> fieldBuilders, Type[] parameterBuilders) {
-      Type[] ctorParams = parameterBuilders;
-      var ctorBuilder = typBuilder.DefineConstructor(
-        MethodAttributes.Public |
-        MethodAttributes.SpecialName |
-        MethodAttributes.RTSpecialName,
-        CallingConventions.Standard,
-        ctorParams);
+            // var openGenericType = typBuilder.CreateType();
+            var openGenericType = typBuilder.CreateTypeInfo();
+            var returnType = openGenericType.MakeGenericType(info.PropertyTypes.ToArray());
+            //OnDynamicEntityTypeCreated(new DynamicEntityTypeCreatedEventArgs(returnType));
+            //if (info.DynamicTypeShouldSave) {
 
-      ILGenerator ctorIL = ctorBuilder.GetILGenerator();
-      ctorIL.Emit(OpCodes.Ldarg_0);
-      // var baseCtorInfo = typeof(Object).GetConstructor(new Type[0]);
-      var baseCtorInfo = typeof(DynamicTypeBase).GetTypeInfo().GetConstructor(new Type[0]);
-      ctorIL.Emit(OpCodes.Call, baseCtorInfo);
-      for (byte i = 0; i < info.PropertyNames.Count; i++) {
-        ctorIL.Emit(OpCodes.Ldarg_0);
-        if (i == 0) {
-          ctorIL.Emit(OpCodes.Ldarg_1);
-        } else if (i == 1) {
-          ctorIL.Emit(OpCodes.Ldarg_2);
-        } else if (i == 2) {
-          ctorIL.Emit(OpCodes.Ldarg_3);
-        } else {
-          ctorIL.Emit(OpCodes.Ldarg_S, i + 1);
+            //  asmBuilder.Save(asmBuilder.GetName().Name + ".dll");
+
+            //}
+
+            return returnType;
+
         }
-        ctorIL.Emit(OpCodes.Stfld, fieldBuilders[i]);
-      }
-      //Get the base constructor
 
-      ctorIL.Emit(OpCodes.Ret);
+        private static AssemblyBuilder BuildAssembly(DynamicTypeInfo info)
+        {
+            //AppDomain aDomain = Thread.GetDomain();
+
+            //// Build the assembly
+            //AssemblyName asmName = new AssemblyName();
+            //asmName.Name = info.DynamicTypeName + DynamicTypeInfo.DynamicAssemblyNameSuffix;
+            //AssemblyBuilder asmBuilder;
+
+            //if (info.DynamicTypeShouldSave) {
+            //  if (String.IsNullOrEmpty(info.DynamicTypeFileDirectory)) {
+            //    asmBuilder = aDomain.DefineDynamicAssembly(asmName, AssemblyBuilderAccess.RunAndSave);
+            //  } else {
+            //    asmBuilder = aDomain.DefineDynamicAssembly(asmName, AssemblyBuilderAccess.RunAndSave, info.DynamicTypeFileDirectory);
+            //  }
+            //} else {
+            //  asmBuilder = aDomain.DefineDynamicAssembly(asmName, AssemblyBuilderAccess.Run);
+            //}
+            // return asmBuilder;
+            var asmName = info.DynamicTypeName + DynamicTypeInfo.DynamicAssemblyNameSuffix;
+            var asmBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName(asmName), AssemblyBuilderAccess.Run);
+            return asmBuilder;
+        }
+
+        private static ModuleBuilder BuildModule(DynamicTypeInfo info, AssemblyBuilder asmBuilder)
+        {
+            // Build the module
+            ModuleBuilder modBuilder;
+
+            modBuilder = asmBuilder.DefineDynamicModule("DynamicAnonTypeModule_" + info.TypeName);
+
+            return modBuilder;
+        }
+
+        private static TypeBuilder BuildType(DynamicTypeInfo info, ModuleBuilder modBuilder)
+        {
+            // Build the type
+            var typBuilder = modBuilder.DefineType(info.DynamicTypeName,
+              TypeAttributes.Public |
+              TypeAttributes.Class |
+              TypeAttributes.AutoClass |
+              TypeAttributes.AnsiClass |
+              TypeAttributes.BeforeFieldInit |
+              TypeAttributes.AutoLayout,
+              // typeof(Object));
+              typeof(DynamicTypeBase));
+            return typBuilder;
+        }
+
+        private static Type[] BuildGenericParameters(DynamicTypeInfo info, TypeBuilder typBuilder)
+        {
+            
+            // generates the names T0, T1, T2 ...
+            string[] parameterNames = Enumerable.Range(0, info.PropertyNames.Count).Select(i => "T" + i.ToString()).ToArray();
+            var parameterBuilders = typBuilder.DefineGenericParameters(parameterNames).ToArray();
+            return parameterBuilders;
+            //return parameterBuilders.Select( pb => pb. .AsType()).ToArray();
+        }
+
+        private static void BuildCtor(DynamicTypeInfo info, TypeBuilder typBuilder,
+          List<FieldBuilder> fieldBuilders, Type[] parameterBuilders)
+        {
+            Type[] ctorParams = parameterBuilders;
+            var ctorBuilder = typBuilder.DefineConstructor(
+              MethodAttributes.Public |
+              MethodAttributes.SpecialName |
+              MethodAttributes.RTSpecialName,
+              CallingConventions.Standard,
+              ctorParams);
+
+            ILGenerator ctorIL = ctorBuilder.GetILGenerator();
+            ctorIL.Emit(OpCodes.Ldarg_0);
+            // var baseCtorInfo = typeof(Object).GetConstructor(new Type[0]);
+            var baseCtorInfo = typeof(DynamicTypeBase).GetTypeInfo().GetConstructor(new Type[0]);
+            ctorIL.Emit(OpCodes.Call, baseCtorInfo);
+            for (byte i = 0; i < info.PropertyNames.Count; i++)
+            {
+                ctorIL.Emit(OpCodes.Ldarg_0);
+                if (i == 0)
+                {
+                    ctorIL.Emit(OpCodes.Ldarg_1);
+                }
+                else if (i == 1)
+                {
+                    ctorIL.Emit(OpCodes.Ldarg_2);
+                }
+                else if (i == 2)
+                {
+                    ctorIL.Emit(OpCodes.Ldarg_3);
+                }
+                else
+                {
+                    ctorIL.Emit(OpCodes.Ldarg_S, i + 1);
+                }
+                ctorIL.Emit(OpCodes.Stfld, fieldBuilders[i]);
+            }
+            //Get the base constructor
+
+            ctorIL.Emit(OpCodes.Ret);
+        }
+
+        private static void BuildEmptyCtor(DynamicTypeInfo info, TypeBuilder typBuilder)
+        {
+            var ctorBuilder = typBuilder.DefineConstructor(
+              MethodAttributes.Public |
+              MethodAttributes.SpecialName |
+              MethodAttributes.RTSpecialName,
+              CallingConventions.Standard,
+              new Type[0]);
+
+            var generator = ctorBuilder.GetILGenerator();
+            generator.Emit(OpCodes.Ldarg_0);
+            var baseCtorInfo = typeof(Object).GetTypeInfo().GetConstructor(new Type[0]);
+            generator.Emit(OpCodes.Call, baseCtorInfo);
+            generator.Emit(OpCodes.Ret);
+        }
+
+        private static void BuildProperties(DynamicTypeInfo info, TypeBuilder typBuilder,
+          List<FieldBuilder> fieldBuilders, Type[] parameterBuilders)
+        {
+            for (int i = 0; i < info.PropertyNames.Count; i++)
+            {
+                //var propBuilder = typBuilder.DefineProperty(
+                //  info.PropertyNames[i], PropertyAttributes.None, parameterBuilders[i], Type.EmptyTypes);
+                var propBuilder = typBuilder.DefineProperty(
+                  info.PropertyNames[i], PropertyAttributes.HasDefault, parameterBuilders[i], Type.EmptyTypes);
+
+                // Build Get prop
+                var getMethBuilder = typBuilder.DefineMethod(
+                  "get_" + info.PropertyNames[i], MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.HideBySig,
+                  parameterBuilders[i], Type.EmptyTypes);
+                var generator = getMethBuilder.GetILGenerator();
+
+                generator.Emit(OpCodes.Ldarg_0); // load 'this'
+                generator.Emit(OpCodes.Ldfld, fieldBuilders[i]); // load the field
+                generator.Emit(OpCodes.Ret);
+                propBuilder.SetGetMethod(getMethBuilder);
+
+                // Build Set prop
+                var setMethBuilder = typBuilder.DefineMethod(
+                  "set_" + info.PropertyNames[i], MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.HideBySig,
+                  typeof(void), new Type[] { fieldBuilders[i].FieldType });
+                generator = setMethBuilder.GetILGenerator();
+
+                generator.Emit(OpCodes.Ldarg_0); // load 'this'
+                generator.Emit(OpCodes.Ldarg_1); // load value
+                generator.Emit(OpCodes.Stfld, fieldBuilders[i]);
+                generator.Emit(OpCodes.Ret);
+                propBuilder.SetSetMethod(setMethBuilder);
+            }
+        }
+
+        //// This method does not work for Silverlight. It executes but the call to Equals fails with a VerificationException at runtime
+        //private static void BuildEqualsMethod(DynamicTypeInfo info, TypeBuilder typBuilder, List<FieldBuilder> fields) {
+        //  var methodBuilder = typBuilder.DefineMethod("Equals",
+        //      MethodAttributes.Public | MethodAttributes.ReuseSlot |
+        //      MethodAttributes.Virtual | MethodAttributes.HideBySig,
+        //      typeof(bool), new Type[] { typeof(object) });
+        //  var generator = methodBuilder.GetILGenerator();
+        //  LocalBuilder other = generator.DeclareLocal(typBuilder);
+        //  Label next = generator.DefineLabel();
+        //  generator.Emit(OpCodes.Ldarg_1);
+        //  generator.Emit(OpCodes.Isinst, typBuilder);
+        //  generator.Emit(OpCodes.Stloc, other);
+        //  generator.Emit(OpCodes.Ldloc, other);
+        //  generator.Emit(OpCodes.Brtrue_S, next);
+        //  generator.Emit(OpCodes.Ldc_I4_0);
+        //  generator.Emit(OpCodes.Ret);
+        //  generator.MarkLabel(next);
+
+        //  var tuples = info.PropertyTypes.Zip(fields, (t, f) => Tuple.Create(t, f));
+        //  foreach (var tuple in tuples) {
+        //    // can't use field.FieldType because it returns an unresolved generic type.
+        //    Type fieldType = tuple.Item1; // field.FieldType;
+        //    FieldBuilder field = tuple.Item2;
+
+        //    Type ct = typeof(EqualityComparer<>).MakeGenericType(fieldType);
+        //    next = generator.DefineLabel();
+        //    generator.EmitCall(OpCodes.Call, ct.GetMethod("get_Default"), null);
+        //    generator.Emit(OpCodes.Ldarg_0);
+        //    generator.Emit(OpCodes.Ldfld, field);
+        //    generator.Emit(OpCodes.Ldloc, other);
+        //    generator.Emit(OpCodes.Ldfld, field);
+        //    generator.EmitCall(OpCodes.Callvirt, ct.GetMethod("Equals", new Type[] { fieldType, fieldType }), null);
+        //    generator.Emit(OpCodes.Brtrue_S, next);
+        //    generator.Emit(OpCodes.Ldc_I4_0);
+        //    generator.Emit(OpCodes.Ret);
+        //    generator.MarkLabel(next);
+        //  }
+        //  generator.Emit(OpCodes.Ldc_I4_1);
+        //  generator.Emit(OpCodes.Ret);
+        //}
+
+        //// This method does not work for Silverlight. It executes but the call to GetHashCode fails with a VerificationException at runtime
+        //private static void BuildGetHashCodeMethod(DynamicTypeInfo info, TypeBuilder typBuilder, List<FieldBuilder> fields) {
+        //  var mb = typBuilder.DefineMethod("GetHashCode",
+        //      MethodAttributes.Public | MethodAttributes.ReuseSlot |
+        //      MethodAttributes.Virtual | MethodAttributes.HideBySig,
+        //      typeof(int), Type.EmptyTypes);
+        //  var generator = mb.GetILGenerator();
+        //  generator.Emit(OpCodes.Ldc_I4_0);
+        //  var tuples = info.PropertyTypes.Zip(fields, (t, f) => Tuple.Create(t, f));
+        //  foreach (var tuple in tuples) {
+        //    Type fieldType = tuple.Item1; //  field.FieldType;
+        //    var field = tuple.Item2;
+        //    Type ct = typeof(EqualityComparer<>).MakeGenericType(fieldType);
+        //    generator.EmitCall(OpCodes.Call, ct.GetMethod("get_Default"), null);
+        //    generator.Emit(OpCodes.Ldarg_0);
+        //    generator.Emit(OpCodes.Ldfld, field);
+        //    generator.EmitCall(OpCodes.Callvirt, ct.GetMethod("GetHashCode", new Type[] { fieldType }), null);
+        //    generator.Emit(OpCodes.Xor);
+        //  }
+        //  generator.Emit(OpCodes.Ret);
+        //}
+
+
+        private static IEnumerable<FieldBuilder> BuildFields(DynamicTypeInfo info,
+          TypeBuilder typBuilder, Type[] parameterBuilders)
+        {
+            var propertyCount = info.PropertyNames.Count;
+            for (int i = 0; i < propertyCount; i++)
+            {
+                yield return typBuilder.DefineField("_" + info.PropertyNames[i], parameterBuilders[i],
+                  FieldAttributes.Private | FieldAttributes.InitOnly);
+            }
+        }
+
     }
-
-    private static void BuildEmptyCtor(DynamicTypeInfo info, TypeBuilder typBuilder) {
-      var ctorBuilder = typBuilder.DefineConstructor(
-        MethodAttributes.Public |
-        MethodAttributes.SpecialName |
-        MethodAttributes.RTSpecialName,
-        CallingConventions.Standard,
-        new Type[0]);
-
-      var generator = ctorBuilder.GetILGenerator();
-      generator.Emit(OpCodes.Ldarg_0);
-      var baseCtorInfo = typeof(Object).GetTypeInfo().GetConstructor(new Type[0]);
-      generator.Emit(OpCodes.Call, baseCtorInfo);
-      generator.Emit(OpCodes.Ret);
-    }
-
-    private static void BuildProperties(DynamicTypeInfo info, TypeBuilder typBuilder,
-      List<FieldBuilder> fieldBuilders, Type[] parameterBuilders) {
-      for (int i = 0; i < info.PropertyNames.Count; i++) {
-        //var propBuilder = typBuilder.DefineProperty(
-        //  info.PropertyNames[i], PropertyAttributes.None, parameterBuilders[i], Type.EmptyTypes);
-        var propBuilder = typBuilder.DefineProperty(
-          info.PropertyNames[i], PropertyAttributes.HasDefault, parameterBuilders[i], Type.EmptyTypes);
-
-        // Build Get prop
-        var getMethBuilder = typBuilder.DefineMethod(
-          "get_" + info.PropertyNames[i], MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.HideBySig,
-          parameterBuilders[i], Type.EmptyTypes);
-        var generator = getMethBuilder.GetILGenerator();
-
-        generator.Emit(OpCodes.Ldarg_0); // load 'this'
-        generator.Emit(OpCodes.Ldfld, fieldBuilders[i]); // load the field
-        generator.Emit(OpCodes.Ret);
-        propBuilder.SetGetMethod(getMethBuilder);
-
-        // Build Set prop
-        var setMethBuilder = typBuilder.DefineMethod(
-          "set_" + info.PropertyNames[i], MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.HideBySig,
-          typeof(void), new Type[] { fieldBuilders[i].FieldType });
-        generator = setMethBuilder.GetILGenerator();
-
-        generator.Emit(OpCodes.Ldarg_0); // load 'this'
-        generator.Emit(OpCodes.Ldarg_1); // load value
-        generator.Emit(OpCodes.Stfld, fieldBuilders[i]);
-        generator.Emit(OpCodes.Ret);
-        propBuilder.SetSetMethod(setMethBuilder);
-      }
-    }
-
-    //// This method does not work for Silverlight. It executes but the call to Equals fails with a VerificationException at runtime
-    //private static void BuildEqualsMethod(DynamicTypeInfo info, TypeBuilder typBuilder, List<FieldBuilder> fields) {
-    //  var methodBuilder = typBuilder.DefineMethod("Equals",
-    //      MethodAttributes.Public | MethodAttributes.ReuseSlot |
-    //      MethodAttributes.Virtual | MethodAttributes.HideBySig,
-    //      typeof(bool), new Type[] { typeof(object) });
-    //  var generator = methodBuilder.GetILGenerator();
-    //  LocalBuilder other = generator.DeclareLocal(typBuilder);
-    //  Label next = generator.DefineLabel();
-    //  generator.Emit(OpCodes.Ldarg_1);
-    //  generator.Emit(OpCodes.Isinst, typBuilder);
-    //  generator.Emit(OpCodes.Stloc, other);
-    //  generator.Emit(OpCodes.Ldloc, other);
-    //  generator.Emit(OpCodes.Brtrue_S, next);
-    //  generator.Emit(OpCodes.Ldc_I4_0);
-    //  generator.Emit(OpCodes.Ret);
-    //  generator.MarkLabel(next);
-
-    //  var tuples = info.PropertyTypes.Zip(fields, (t, f) => Tuple.Create(t, f));
-    //  foreach (var tuple in tuples) {
-    //    // can't use field.FieldType because it returns an unresolved generic type.
-    //    Type fieldType = tuple.Item1; // field.FieldType;
-    //    FieldBuilder field = tuple.Item2;
-
-    //    Type ct = typeof(EqualityComparer<>).MakeGenericType(fieldType);
-    //    next = generator.DefineLabel();
-    //    generator.EmitCall(OpCodes.Call, ct.GetMethod("get_Default"), null);
-    //    generator.Emit(OpCodes.Ldarg_0);
-    //    generator.Emit(OpCodes.Ldfld, field);
-    //    generator.Emit(OpCodes.Ldloc, other);
-    //    generator.Emit(OpCodes.Ldfld, field);
-    //    generator.EmitCall(OpCodes.Callvirt, ct.GetMethod("Equals", new Type[] { fieldType, fieldType }), null);
-    //    generator.Emit(OpCodes.Brtrue_S, next);
-    //    generator.Emit(OpCodes.Ldc_I4_0);
-    //    generator.Emit(OpCodes.Ret);
-    //    generator.MarkLabel(next);
-    //  }
-    //  generator.Emit(OpCodes.Ldc_I4_1);
-    //  generator.Emit(OpCodes.Ret);
-    //}
-
-    //// This method does not work for Silverlight. It executes but the call to GetHashCode fails with a VerificationException at runtime
-    //private static void BuildGetHashCodeMethod(DynamicTypeInfo info, TypeBuilder typBuilder, List<FieldBuilder> fields) {
-    //  var mb = typBuilder.DefineMethod("GetHashCode",
-    //      MethodAttributes.Public | MethodAttributes.ReuseSlot |
-    //      MethodAttributes.Virtual | MethodAttributes.HideBySig,
-    //      typeof(int), Type.EmptyTypes);
-    //  var generator = mb.GetILGenerator();
-    //  generator.Emit(OpCodes.Ldc_I4_0);
-    //  var tuples = info.PropertyTypes.Zip(fields, (t, f) => Tuple.Create(t, f));
-    //  foreach (var tuple in tuples) {
-    //    Type fieldType = tuple.Item1; //  field.FieldType;
-    //    var field = tuple.Item2;
-    //    Type ct = typeof(EqualityComparer<>).MakeGenericType(fieldType);
-    //    generator.EmitCall(OpCodes.Call, ct.GetMethod("get_Default"), null);
-    //    generator.Emit(OpCodes.Ldarg_0);
-    //    generator.Emit(OpCodes.Ldfld, field);
-    //    generator.EmitCall(OpCodes.Callvirt, ct.GetMethod("GetHashCode", new Type[] { fieldType }), null);
-    //    generator.Emit(OpCodes.Xor);
-    //  }
-    //  generator.Emit(OpCodes.Ret);
-    //}
-
-
-    private static IEnumerable<FieldBuilder> BuildFields(DynamicTypeInfo info,
-      TypeBuilder typBuilder, Type[] parameterBuilders) {
-      var propertyCount = info.PropertyNames.Count;
-      for (int i = 0; i < propertyCount; i++) {
-        yield return typBuilder.DefineField("_" + info.PropertyNames[i], parameterBuilders[i],
-          FieldAttributes.Private | FieldAttributes.InitOnly);
-      }
-    }
-
-  }
 }

--- a/AspNetCore/Breeze.Persistence.EFCore/Breeze.Persistence.EFCore.csproj
+++ b/AspNetCore/Breeze.Persistence.EFCore/Breeze.Persistence.EFCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <PackageId>Breeze.Persistence.EFCore</PackageId>
     <PackageVersion>0.0.2</PackageVersion>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
@@ -28,7 +28,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.2.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AspNetCore/Breeze.Persistence/Breeze.Persistence.csproj
+++ b/AspNetCore/Breeze.Persistence/Breeze.Persistence.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <PackageId>Breeze.Persistence</PackageId>
     <PackageVersion>0.0.2</PackageVersion>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
@@ -28,7 +28,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updating breeze to .net core 3.0 
removed 1 bug by removing line of code
my project currently works fine (Save And load)
commented line below, i dont know that it does and didnt find any reference what it is even.

 private static Type[] BuildGenericParameters(DynamicTypeInfo info, TypeBuilder typBuilder)
        {
            
            // generates the names T0, T1, T2 ...
            string[] parameterNames = Enumerable.Range(0, info.PropertyNames.Count).Select(i => "T" + i.ToString()).ToArray();
            var parameterBuilders = typBuilder.DefineGenericParameters(parameterNames).ToArray();
            return parameterBuilders;
            //return parameterBuilders.Select( pb => pb. .AsType()).ToArray();
        }
```