### PR TITLE
Fixed issue with 'in' operator only working with strings

### DIFF
--- a/AspNetCore-v5/Breeze.Core/Query/BinaryPredicate.cs
+++ b/AspNetCore-v5/Breeze.Core/Query/BinaryPredicate.cs
@@ -117,9 +117,8 @@ namespace Breeze.Core {
       } else if (op == BinaryOperator.Contains) {
         var mi = TypeFns.GetMethodByExample((String s) => s.Contains("abc"));
         return Expression.Call(expr1, mi, expr2);
-      } else if (op == BinaryOperator.In) {
-        // TODO: need to generalize this past just 'string'
-        var mi = TypeFns.GetMethodByExample((List<String> list) => list.Contains("abc"), expr1.Type);
+      } else if (op == BinaryOperator.In) {        
+        var mi = TypeFns.GetMethodByNameAndType(typeof(List<>), "Contains", expr1.Type);          
         return Expression.Call(expr2, mi, expr1);
       }
 

--- a/AspNetCore-v5/Breeze.Core/TypeFns.cs
+++ b/AspNetCore-v5/Breeze.Core/TypeFns.cs
@@ -346,6 +346,17 @@ namespace Breeze.Core {
       return mi3;
     }
 
+    public static MethodInfo GetMethodByNameAndType(Type containingType, string methodName, params Type[] genericTypeArgs) {
+      MethodInfo mi;
+      if(containingType.IsGenericType) {
+        var constructed = containingType.MakeGenericType(genericTypeArgs);
+        mi = constructed.GetMethod(methodName);
+      } else {
+        mi = containingType.GetMethod(methodName);
+      }            
+      return mi;
+    }
+
     public static MethodInfo GetMethodByExample<TIn1, TIn2, TOut>(Expression<Func<TIn1, TIn2, TOut>> prototypeLambda, params Type[] resolvedTypes) {
       var mi = (prototypeLambda.Body as MethodCallExpression).Method;
       if (!resolvedTypes.Any()) return mi;


### PR DESCRIPTION
If the server is queried with any predicate that uses the "in" operator on a field that is anything other than a string type then it throws an exception in this section in Breeze.Core.BinaryPredicate

else if (op == BinaryOperator.In) {
        // TODO: need to generalize this past just 'string'
        var mi = TypeFns.GetMethodByExample((List<String> list) => list.Contains("abc"), expr1.Type);
        return Expression.Call(expr2, mi, expr1);
      }

This is because mi is List<string>.Contains() but expr1 and expr2 are of type List<T> where T is not a string.

My change should work for any T.
