### PR TITLE
DateOnly and ApplyBreezeQuery

### DIFF
--- a/DotNet/Breeze.AspNetCore.NetCore/Breeze.AspNetCore.NetCore.6.csproj
+++ b/DotNet/Breeze.AspNetCore.NetCore/Breeze.AspNetCore.NetCore.6.csproj
@@ -7,7 +7,7 @@
 		<OutputType>Library</OutputType>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<IsPackable>true</IsPackable>
-		<Version>6.0.2.0</Version>
+		<Version>6.0.2.1</Version>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<Description>Core ASP.NET Core functionality for any Breeze Server using ASP.NET Core.
 Please review the Breeze documentation at http://breeze.github.io/doc-main/
@@ -26,8 +26,8 @@ Please review the Breeze release notes at http://breeze.github.io/doc-net/releas
 		<Product>Breeze Server - ASP.NET Core Provider</Product>
 		<PackageTags>AspNetCore DotNetCore Net6 JavaScript Breeze BreezeJs</PackageTags>
 		<NeutralLanguage>en-US</NeutralLanguage>
-		<AssemblyVersion>6.0.2.0</AssemblyVersion>
-		<FileVersion>6.0.2.0</FileVersion>
+		<AssemblyVersion>6.0.2.1</AssemblyVersion>
+		<FileVersion>6.0.2.1</FileVersion>
 		<PackageIcon>Breeze-aspnet.png</PackageIcon>
 		<RepositoryUrl>https://github.com/Breeze/breeze.server.net</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>

--- a/DotNet/Breeze.AspNetCore.NetCore/Breeze.AspNetCore.NetCore.7.csproj
+++ b/DotNet/Breeze.AspNetCore.NetCore/Breeze.AspNetCore.NetCore.7.csproj
@@ -7,7 +7,7 @@
 		<OutputType>Library</OutputType>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<IsPackable>true</IsPackable>
-		<Version>7.0.1.0</Version>
+		<Version>7.0.1.1</Version>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<Description>Core ASP.NET Core functionality for any Breeze Server using ASP.NET Core.
 Please review the Breeze documentation at http://breeze.github.io/doc-main/
@@ -26,8 +26,8 @@ Please review the Breeze release notes at http://breeze.github.io/doc-net/releas
 		<Product>Breeze Server - ASP.NET Core Provider</Product>
 		<PackageTags>AspNetCore DotNetCore Net7 JavaScript Breeze BreezeJs</PackageTags>
 		<NeutralLanguage>en-US</NeutralLanguage>
-		<AssemblyVersion>7.0.1.0</AssemblyVersion>
-		<FileVersion>7.0.1.0</FileVersion>
+		<AssemblyVersion>7.0.1.1</AssemblyVersion>
+		<FileVersion>7.0.1.1</FileVersion>
 		<PackageIcon>Breeze-aspnet.png</PackageIcon>
 		<RepositoryUrl>https://github.com/Breeze/breeze.server.net</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>

--- a/DotNet/Breeze.AspNetCore.NetCore/Breeze.AspNetCore.NetCore.xml
+++ b/DotNet/Breeze.AspNetCore.NetCore/Breeze.AspNetCore.NetCore.xml
@@ -4,5 +4,103 @@
         <name>Breeze.AspNetCore.NetCore</name>
     </assembly>
     <members>
+        <member name="T:Breeze.AspNetCore.GlobalExceptionFilter">
+            <summary> Filter to capture and return entity errors </summary>
+        </member>
+        <member name="M:Breeze.AspNetCore.GlobalExceptionFilter.#ctor">
+            <summary> Empty constructor </summary>
+        </member>
+        <member name="M:Breeze.AspNetCore.GlobalExceptionFilter.OnException(Microsoft.AspNetCore.Mvc.Filters.ExceptionContext)">
+            <summary> Process exceptions to extract EntityErrors and include them in the response </summary>
+        </member>
+        <member name="T:Breeze.AspNetCore.ErrorDto">
+            <summary> Error object returned to the client </summary>
+        </member>
+        <member name="P:Breeze.AspNetCore.ErrorDto.Code">
+            <summary> HTTP status code </summary>
+        </member>
+        <member name="P:Breeze.AspNetCore.ErrorDto.Message">
+            <summary> Exception message </summary>
+        </member>
+        <member name="P:Breeze.AspNetCore.ErrorDto.StackTrace">
+            <summary> Exception stack trace </summary>
+        </member>
+        <member name="P:Breeze.AspNetCore.ErrorDto.EntityErrors">
+            <summary> Entity validation errors </summary>
+        </member>
+        <member name="M:Breeze.AspNetCore.ErrorDto.ToString">
+            <summary> Return ErrorDto as JSON </summary>
+        </member>
+        <member name="T:Breeze.AspNetCore.BreezeQueryFilterAttribute">
+            <summary> Attribute to apply the request's query string to the returned IQueryable </summary>
+            <remarks> Put [BreezeQueryFilter] on a Controller class to apply Breeze query filtering
+            and execution to each method that returns an IQueryable or IEnumerable.
+            <para></para>
+            See <see href="https://breeze.github.io/doc-net/webapi-controller-core#breezequeryfilterattribute"/>
+            </remarks>
+        </member>
+        <member name="M:Breeze.AspNetCore.BreezeQueryFilterAttribute.OnActionExecuting(Microsoft.AspNetCore.Mvc.Filters.ActionExecutingContext)">
+            <summary> Check if context.ModelState is valid </summary>
+        </member>
+        <member name="M:Breeze.AspNetCore.BreezeQueryFilterAttribute.OnActionExecuted(Microsoft.AspNetCore.Mvc.Filters.ActionExecutedContext)">
+            <summary> Extract the IQueryable from the context, apply the query, and execute it. </summary>
+        </member>
+        <member name="T:Breeze.AspNetCore.QueryFns">
+            <summary> Static utility functions for processing queries </summary>
+        </member>
+        <member name="M:Breeze.AspNetCore.QueryFns.ExtractQueryable(Microsoft.AspNetCore.Mvc.Filters.ActionExecutedContext,System.Boolean)">
+            <summary> Get the IQueryable from the context.Result </summary>
+        </member>
+        <member name="M:Breeze.AspNetCore.QueryFns.ExtractAndDecodeQueryString(Microsoft.AspNetCore.Mvc.ActionContext)">
+            <summary> Get the query string from the HttpRequest </summary>
+        </member>
+        <member name="M:Breeze.AspNetCore.QueryFns.ApplyBreezeQuery``1(Microsoft.AspNetCore.Mvc.ActionContext,System.Linq.IQueryable{``0})">
+            <summary> Apply the Where, Order, Skip, and Take predicates from the request's query string to the IQueryable </summary>
+            <remarks><example> Example: Apply query filtering, then aggregate the results.
+            <code>
+            // Apply EntityQuery to filter the IQueryable before aggregation
+            var query = QueryFns.ApplyBreezeQuery(this.ControllerContext, dbContext.Orders);
+            // Total the results
+            var totals = query.Sum(o => o.TotalAmount).ToList();
+            // Return an object, not an IEnumerable, else Breeze will attempt to apply the query again
+            return new { total = totals[0] };
+            </code></example></remarks>
+        </member>
+        <member name="M:Breeze.AspNetCore.QueryFns.ApplyBreezeQuery``1(Microsoft.AspNetCore.Mvc.ControllerBase,System.Linq.IQueryable{``0})">
+            <summary> Apply the Where, Order, Skip, and Take predicates from the request's query string to the IQueryable </summary>
+            <remarks><example> Example: Apply query filtering, then aggregate the results.
+            <code>
+            // Apply EntityQuery from client to filter the IQueryable before aggregation
+            var query = this.ApplyBreezeQuery(dbContext.Orders);
+            // Total the results
+            var totals = query.Sum(o => o.TotalAmount).ToList();
+            // Return an object, not an IEnumerable, else Breeze will attempt to apply the query again
+            return new { total = totals[0] };
+            </code></example></remarks>
+        </member>
+        <member name="M:Breeze.AspNetCore.QueryFns.ApplyBreezeWhere``1(Microsoft.AspNetCore.Mvc.ActionContext,System.Linq.IQueryable{``0})">
+            <summary> Apply the Where predicate from the request's query string to the IQueryable </summary>
+            <remarks><example> Example: Apply query Where clause, then aggregate the results.
+            <code>
+            // Apply Where clause from client to filter the IQueryable before aggregation
+            var query = QueryFns.ApplyBreezeWhere(this.ControllerContext, dbContext.Orders);
+            // Total the results
+            var totals = query.Sum(o => o.TotalAmount).ToList();
+            // Return an object, not an IEnumerable, else Breeze will attempt to apply the query again
+            return new { total = totals[0] };
+            </code></example></remarks>
+        </member>
+        <member name="M:Breeze.AspNetCore.QueryFns.ApplyBreezeWhere``1(Microsoft.AspNetCore.Mvc.ControllerBase,System.Linq.IQueryable{``0})">
+            <summary> Apply the Where predicate from the request's query string to the IQueryable </summary>
+            <remarks><example> Example: Apply query filtering, then aggregate the results.
+            <code>
+            // Apply Where clause from client to filter the IQueryable before aggregation
+            var query = this.ApplyBreezeWhere(dbContext.Orders);
+            // Total the results
+            var totals = query.Sum(o => o.TotalAmount).ToList();
+            // Return an object, not an IEnumerable, else Breeze will attempt to apply the query again
+            return new { total = totals[0] };
+            </code></example></remarks>
+        </member>
     </members>
 </doc>

--- a/DotNet/Breeze.AspNetCore.NetCore/GlobalExceptionFilter.cs
+++ b/DotNet/Breeze.AspNetCore.NetCore/GlobalExceptionFilter.cs
@@ -1,4 +1,4 @@
-﻿using Breeze.Persistence;
+using Breeze.Persistence;
 
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
@@ -6,12 +6,13 @@ using Newtonsoft.Json;
 using System.Collections.Generic;
 
 namespace Breeze.AspNetCore {
+  /// <summary> Filter to capture and return entity errors </summary>
   public class GlobalExceptionFilter : IExceptionFilter {
 
-    public GlobalExceptionFilter() {
-      
-    }
+    /// <summary> Empty constructor </summary>
+    public GlobalExceptionFilter() {}
 
+    /// <summary> Process exceptions to extract EntityErrors and include them in the response </summary>
     public void OnException(ExceptionContext context) {
       var ex = context.Exception;
       var msg = ex.InnerException == null ? ex.Message : ex.Message + "--" + ex.InnerException.Message;
@@ -38,14 +39,18 @@ namespace Breeze.AspNetCore {
     }
   }
 
+  /// <summary> Error object returned to the client </summary>
   public class ErrorDto {
+    /// <summary> HTTP status code </summary>
     public int Code { get; set; }
+    /// <summary> Exception message </summary>
     public string Message { get; set; }
+    /// <summary> Exception stack trace </summary>
     public string StackTrace { get; set; }
+    /// <summary> Entity validation errors </summary>
     public List<EntityError> EntityErrors { get; set; }
 
-    // other fields
-
+    /// <summary> Return ErrorDto as JSON </summary>
     public override string ToString() {
       return JsonConvert.SerializeObject(this);
     }

--- a/DotNet/Breeze.AspNetCore.NetCore/QueryFilter.cs
+++ b/DotNet/Breeze.AspNetCore.NetCore/QueryFilter.cs
@@ -3,21 +3,26 @@ using Breeze.Core;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
-using System;
-using System.Collections;
 using System.Linq;
-using System.Net;
 
 namespace Breeze.AspNetCore {
 
-
+  /// <summary> Attribute to apply the request's query string to the returned IQueryable </summary>
+  /// <remarks> Put [BreezeQueryFilter] on a Controller class to apply Breeze query filtering
+  /// and execution to each method that returns an IQueryable or IEnumerable.
+  /// <para></para>
+  /// See <see href="https://breeze.github.io/doc-net/webapi-controller-core#breezequeryfilterattribute"/>
+  /// </remarks>
   public class BreezeQueryFilterAttribute : ActionFilterAttribute {
+
+    /// <summary> Check if context.ModelState is valid </summary>
     public override void OnActionExecuting(ActionExecutingContext context) {
       if (!context.ModelState.IsValid) {
         context.Result = new BadRequestObjectResult(context.ModelState);
       }
     }
 
+    /// <summary> Extract the IQueryable from the context, apply the query, and execute it. </summary>
     public override void OnActionExecuted(ActionExecutedContext context) {
 
       // don't attempt to process queryable if we are throwing an error

--- a/DotNet/Breeze.AspNetCore.NetCore/QueryFns.cs
+++ b/DotNet/Breeze.AspNetCore.NetCore/QueryFns.cs
@@ -1,17 +1,17 @@
+using Breeze.Core;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 
 namespace Breeze.AspNetCore {
+  /// <summary> Static utility functions for processing queries </summary>
   public static class QueryFns {
 
+    /// <summary> Get the IQueryable from the context.Result </summary>
     public static IQueryable ExtractQueryable(ActionExecutedContext context, bool throwOnError = false) {
       var objResult = context.Result as ObjectResult;
       if (objResult == null) {
@@ -33,6 +33,8 @@ namespace Breeze.AspNetCore {
       }
       return queryable;
     }
+
+    /// <summary> Get the query string from the HttpRequest </summary>
     public static string ExtractAndDecodeQueryString(ActionContext context) {
       var qs = context.HttpContext.Request.QueryString;
       var q = WebUtility.UrlDecode(qs.Value);
@@ -56,5 +58,80 @@ namespace Breeze.AspNetCore {
       }
       return q;
     }
+
+    /// <summary> Apply the Where, Order, Skip, and Take predicates from the request's query string to the IQueryable </summary>
+    /// <remarks><example> Example: Apply query filtering, then aggregate the results.
+    /// <code>
+    /// // Apply EntityQuery to filter the IQueryable before aggregation
+    /// var query = QueryFns.ApplyBreezeQuery(this.ControllerContext, dbContext.Orders);
+    /// // Total the results
+    /// var totals = query.Sum(o => o.TotalAmount).ToList();
+    /// // Return an object, not an IEnumerable, else Breeze will attempt to apply the query again
+    /// return new { total = totals[0] };
+    /// </code></example></remarks>
+    public static IQueryable<T> ApplyBreezeQuery<T>(ActionContext context, IQueryable<T> queryable) {
+      // Build Breeze EntityQuery from string parameters
+      var qs = QueryFns.ExtractAndDecodeQueryString(context);
+      var eq = new EntityQuery(qs);
+      eq.Validate(typeof(T));
+
+      // Apply EntityQuery to filter the IQueryable before query execution
+      queryable = eq.ApplyWhere(queryable, typeof(T)) as IQueryable<T>;
+      queryable = EntityQuery.ApplyCustomLogic(eq, queryable, typeof(T)) as IQueryable<T>;
+      queryable = eq.ApplyOrderBy(queryable, typeof(T)) as IQueryable<T>;
+      queryable = eq.ApplySkip(queryable, typeof(T)) as IQueryable<T>;
+      queryable = eq.ApplyTake(queryable, typeof(T)) as IQueryable<T>;
+      return queryable;
+    }
+
+    /// <summary> Apply the Where, Order, Skip, and Take predicates from the request's query string to the IQueryable </summary>
+    /// <remarks><example> Example: Apply query filtering, then aggregate the results.
+    /// <code>
+    /// // Apply EntityQuery from client to filter the IQueryable before aggregation
+    /// var query = this.ApplyBreezeQuery(dbContext.Orders);
+    /// // Total the results
+    /// var totals = query.Sum(o => o.TotalAmount).ToList();
+    /// // Return an object, not an IEnumerable, else Breeze will attempt to apply the query again
+    /// return new { total = totals[0] };
+    /// </code></example></remarks>
+    public static IQueryable<T> ApplyBreezeQuery<T>(this ControllerBase controller, IQueryable<T> queryable) {
+      return ApplyBreezeQuery(controller.ControllerContext, queryable);
+    }
+
+    /// <summary> Apply the Where predicate from the request's query string to the IQueryable </summary>
+    /// <remarks><example> Example: Apply query Where clause, then aggregate the results.
+    /// <code>
+    /// // Apply Where clause from client to filter the IQueryable before aggregation
+    /// var query = QueryFns.ApplyBreezeWhere(this.ControllerContext, dbContext.Orders);
+    /// // Total the results
+    /// var totals = query.Sum(o => o.TotalAmount).ToList();
+    /// // Return an object, not an IEnumerable, else Breeze will attempt to apply the query again
+    /// return new { total = totals[0] };
+    /// </code></example></remarks>
+    public static IQueryable<T> ApplyBreezeWhere<T>(ActionContext context, IQueryable<T> queryable) {
+      // Build Breeze EntityQuery from string parameters
+      var qs = QueryFns.ExtractAndDecodeQueryString(context);
+      var eq = new EntityQuery(qs);
+      eq.Validate(typeof(T));
+
+      // Apply EntityQuery Where clause to filter the IQueryable before query execution
+      queryable = eq.ApplyWhere(queryable, typeof(T)) as IQueryable<T>;
+      return queryable;
+    }
+
+    /// <summary> Apply the Where predicate from the request's query string to the IQueryable </summary>
+    /// <remarks><example> Example: Apply query filtering, then aggregate the results.
+    /// <code>
+    /// // Apply Where clause from client to filter the IQueryable before aggregation
+    /// var query = this.ApplyBreezeWhere(dbContext.Orders);
+    /// // Total the results
+    /// var totals = query.Sum(o => o.TotalAmount).ToList();
+    /// // Return an object, not an IEnumerable, else Breeze will attempt to apply the query again
+    /// return new { total = totals[0] };
+    /// </code></example></remarks>
+    public static IQueryable<T> ApplyBreezeWhere<T>(this ControllerBase controller, IQueryable<T> queryable) {
+      return ApplyBreezeWhere(controller.ControllerContext, queryable);
+    }
+
   }
 }

--- a/DotNet/Breeze.Core/Breeze.Core.6.csproj
+++ b/DotNet/Breeze.Core/Breeze.Core.6.csproj
@@ -5,7 +5,7 @@
 		<SignAssembly>true</SignAssembly>
 		<AssemblyOriginatorKeyFile>Breeze.snk</AssemblyOriginatorKeyFile>
 		<IsPackable>true</IsPackable>
-		<Version>6.0.2.0</Version>
+		<Version>6.0.2.1</Version>
 		<Description>Core functionality for any Breeze Server using .NET.
 Please review the Breeze documentation at http://breeze.github.io/doc-main/
 
@@ -25,8 +25,8 @@ Please review the Breeze release notes at http://breeze.github.io/doc-net/releas
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<DelaySign>false</DelaySign>
-		<AssemblyVersion>6.0.2.0</AssemblyVersion>
-		<FileVersion>6.0.2.0</FileVersion>
+		<AssemblyVersion>6.0.2.1</AssemblyVersion>
+		<FileVersion>6.0.2.1</FileVersion>
 		<PackageIcon>BreezeLogo.png</PackageIcon>
 		<RepositoryUrl>https://github.com/Breeze/breeze.server.net</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>

--- a/DotNet/Breeze.Core/Breeze.Core.7.csproj
+++ b/DotNet/Breeze.Core/Breeze.Core.7.csproj
@@ -5,7 +5,7 @@
 		<SignAssembly>true</SignAssembly>
 		<AssemblyOriginatorKeyFile>Breeze.snk</AssemblyOriginatorKeyFile>
 		<IsPackable>true</IsPackable>
-		<Version>7.0.1.0</Version>
+		<Version>7.0.1.1</Version>
 		<Description>Core functionality for any Breeze Server using .NET.
 Please review the Breeze documentation at http://breeze.github.io/doc-main/
 
@@ -25,8 +25,8 @@ Please review the Breeze release notes at http://breeze.github.io/doc-net/releas
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<DelaySign>false</DelaySign>
-		<AssemblyVersion>7.0.1.0</AssemblyVersion>
-		<FileVersion>7.0.1.0</FileVersion>
+		<AssemblyVersion>7.0.1.1</AssemblyVersion>
+		<FileVersion>7.0.1.1</FileVersion>
 		<PackageIcon>BreezeLogo.png</PackageIcon>
 		<RepositoryUrl>https://github.com/Breeze/breeze.server.net</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>

--- a/DotNet/Breeze.Core/Query/DataType.cs
+++ b/DotNet/Breeze.Core/Query/DataType.cs
@@ -1,4 +1,4 @@
-﻿
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -30,8 +30,10 @@ namespace Breeze.Core {
     public static DataType Decimal = new DataType("Decimal", typeof(Decimal));
     public static DataType Double = new DataType("Double", typeof(Double));
     public static DataType Single = new DataType("Single", typeof(Single));
-
-
+#if NET6_0_OR_GREATER
+    public static DataType DateOnly = new DataType("DateOnly", typeof(DateOnly));
+    public static DataType TimeOnly = new DataType("TimeOnly", typeof(TimeOnly));
+#endif
 
     public DataType(String name) {
       _name = name;
@@ -87,6 +89,12 @@ namespace Breeze.Core {
         return result;
       } else if (dataType == DataType.Time && value is String) {
         return XmlConvert.ToTimeSpan((string)value);
+#if NET6_0_OR_GREATER
+      } else if (dataType == DataType.DateOnly && value is String) {
+        return System.DateOnly.Parse((string)value);
+      } else if (dataType == DataType.TimeOnly && value is String) {
+        return System.TimeOnly.Parse((string)value);
+#endif
       } else {
         return Convert.ChangeType(value, dataType.GetUnderlyingType());
       }

--- a/DotNet/Breeze.Core/TypeFns.cs
+++ b/DotNet/Breeze.Core/TypeFns.cs
@@ -68,6 +68,10 @@ namespace Breeze.Core {
             typeof(Decimal),
             typeof(DateTime),
             typeof(DateTimeOffset),
+#if NET6_0_OR_GREATER
+            typeof(DateOnly),
+            typeof(TimeOnly),
+#endif
             typeof(TimeSpan),
             typeof(Guid),
             typeof(Math),

--- a/DotNet/Breeze.Persistence.EFCore/Breeze.Persistence.EFCore.6.csproj
+++ b/DotNet/Breeze.Persistence.EFCore/Breeze.Persistence.EFCore.6.csproj
@@ -6,7 +6,7 @@
 		<AssemblyOriginatorKeyFile>Breeze.snk</AssemblyOriginatorKeyFile>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<IsPackable>true</IsPackable>
-		<Version>6.0.2.0</Version>
+		<Version>6.0.2.1</Version>
 		<Description>Persistence for EF Core functionality for any Breeze Server using .NET.
 Please review the Breeze documentation at http://breeze.github.io/doc-main/
 
@@ -25,8 +25,8 @@ Please review the Breeze release notes at http://breeze.github.io/doc-net/releas
 		<PackageTags>AspNetCore DotNetCore Net6 EFCore EntityFramework JavaScript Breeze BreezeJs</PackageTags>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<DelaySign>false</DelaySign>
-		<AssemblyVersion>6.0.2.0</AssemblyVersion>
-		<FileVersion>6.0.2.0</FileVersion>
+		<AssemblyVersion>6.0.2.1</AssemblyVersion>
+		<FileVersion>6.0.2.1</FileVersion>
 		<PackageIcon>BreezeLogo.png</PackageIcon>
 		<RepositoryUrl>https://github.com/Breeze/breeze.server.net</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>

--- a/DotNet/Breeze.Persistence.EFCore/Breeze.Persistence.EFCore.7.csproj
+++ b/DotNet/Breeze.Persistence.EFCore/Breeze.Persistence.EFCore.7.csproj
@@ -6,7 +6,7 @@
 		<AssemblyOriginatorKeyFile>Breeze.snk</AssemblyOriginatorKeyFile>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<IsPackable>true</IsPackable>
-		<Version>7.0.1.0</Version>
+		<Version>7.0.1.1</Version>
 		<Description>Persistence for EF Core functionality for any Breeze Server using .NET.
 Please review the Breeze documentation at http://breeze.github.io/doc-main/
 
@@ -25,8 +25,8 @@ Please review the Breeze release notes at http://breeze.github.io/doc-net/releas
 		<PackageTags>AspNetCore DotNetCore Net7 EFCore EntityFramework JavaScript Breeze BreezeJs</PackageTags>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<DelaySign>false</DelaySign>
-		<AssemblyVersion>7.0.1.0</AssemblyVersion>
-		<FileVersion>7.0.1.0</FileVersion>
+		<AssemblyVersion>7.0.1.1</AssemblyVersion>
+		<FileVersion>7.0.1.1</FileVersion>
 		<PackageIcon>BreezeLogo.png</PackageIcon>
 		<RepositoryUrl>https://github.com/Breeze/breeze.server.net</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>

--- a/DotNet/Breeze.Persistence/Breeze.Persistence.6.csproj
+++ b/DotNet/Breeze.Persistence/Breeze.Persistence.6.csproj
@@ -5,7 +5,7 @@
 		<SignAssembly>true</SignAssembly>
 		<AssemblyOriginatorKeyFile>Breeze.snk</AssemblyOriginatorKeyFile>
 		<IsPackable>true</IsPackable>
-		<Version>6.0.2.0</Version>
+		<Version>6.0.2.1</Version>
 		<Description>Basic Persistence functionality for any Breeze Server using .NET.
 Please review the Breeze documentation at http://breeze.github.io/doc-main/
 
@@ -25,8 +25,8 @@ Please review the Breeze release notes at http://breeze.github.io/doc-net/releas
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<DelaySign>false</DelaySign>
-		<AssemblyVersion>6.0.2.0</AssemblyVersion>
-		<FileVersion>6.0.2.0</FileVersion>
+		<AssemblyVersion>6.0.2.1</AssemblyVersion>
+		<FileVersion>6.0.2.1</FileVersion>
 		<PackageIcon>BreezeLogo.png</PackageIcon>
 		<RepositoryUrl>https://github.com/Breeze/breeze.server.net</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>

--- a/DotNet/Breeze.Persistence/Breeze.Persistence.7.csproj
+++ b/DotNet/Breeze.Persistence/Breeze.Persistence.7.csproj
@@ -5,7 +5,7 @@
 		<SignAssembly>true</SignAssembly>
 		<AssemblyOriginatorKeyFile>Breeze.snk</AssemblyOriginatorKeyFile>
 		<IsPackable>true</IsPackable>
-		<Version>7.0.1.0</Version>
+		<Version>7.0.1.1</Version>
 		<Description>Basic Persistence functionality for any Breeze Server using .NET.
 Please review the Breeze documentation at http://breeze.github.io/doc-main/
 
@@ -25,8 +25,8 @@ Please review the Breeze release notes at http://breeze.github.io/doc-net/releas
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<DelaySign>false</DelaySign>
-		<AssemblyVersion>7.0.1.0</AssemblyVersion>
-		<FileVersion>7.0.1.0</FileVersion>
+		<AssemblyVersion>7.0.1.1</AssemblyVersion>
+		<FileVersion>7.0.1.1</FileVersion>
 		<PackageIcon>BreezeLogo.png</PackageIcon>
 		<RepositoryUrl>https://github.com/Breeze/breeze.server.net</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>

--- a/DotNet/tools/deploy.js
+++ b/DotNet/tools/deploy.js
@@ -6,7 +6,7 @@ var del = require('del');
 const bu = require('.\\build-utils');
 
 const localNugetCacheDir = process.env.LOCALAPPDATA + '\\NuGet\\Test';
-const version = '7.0.1';
+const version = '6.0.2.1';
 const debugOrRelease = 'Release';
 
 var baseNames = [

--- a/Tests/Databases/Add_DateOnly_TimeOnly.sql
+++ b/Tests/Databases/Add_DateOnly_TimeOnly.sql
@@ -1,0 +1,11 @@
+USE [NorthwindIB]
+GO
+
+BEGIN TRANSACTION
+GO
+ALTER TABLE [dbo].[UnusualDate] ADD
+	[DateOnly] [date] NULL,
+	[TimeOnly] [time](7) NULL
+GO
+COMMIT
+GO


### PR DESCRIPTION
 - Add types and parsing code to DataType class
 - Add DateOnly and TimeOnly to TypeFns.PredefinedTypes
 - Add ApplyBreezeQuery and ApplyBreezeWhere to QueryFns
 - Add XML comments
 - Add +0.0.0.1 to version numbers for local deploy; (update again for release)
 - Tests: Add DateOnly and TimeOnly properties to UnusualDate entity
 - Tests: Add ALTER TABLE script to Database folder, to add the columns
 - Tests: Add ValueConverters and ValueComparers so EF can save and retrieve the DateOnly and TimeOnly columns
