### PR TITLE
Add ability to use cancellation tokens with BreezeQueryFilter

### DIFF
--- a/DotNet/Breeze.AspNetCore.NetCore/QueryFilter.cs
+++ b/DotNet/Breeze.AspNetCore.NetCore/QueryFilter.cs
@@ -85,8 +85,8 @@ namespace Breeze.AspNetCore {
             executedContext.Result = new ObjectResult(emptyResult);
           }
         } else {
-          var listResult = Enumerable.ToList((dynamic) queryable);
-          listResult = EntityQuery.AfterExecution(eq, queryable, listResult);
+          var result = await queryable.Cast<dynamic>().ToListAsync(cancellationToken);
+          var listResult = EntityQuery.AfterExecution(eq, queryable, result);
 
           var qr = new QueryResult(listResult, inlineCount);
           executedContext.Result = new ObjectResult(qr);

--- a/DotNet/Breeze.AspNetCore.NetCore/QueryFilter.cs
+++ b/DotNet/Breeze.AspNetCore.NetCore/QueryFilter.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using System.Linq;
+using Breeze.AspNetCore.NetCore;
 
 namespace Breeze.AspNetCore {
 

--- a/DotNet/Breeze.AspNetCore.NetCore/QueryFilter.cs
+++ b/DotNet/Breeze.AspNetCore.NetCore/QueryFilter.cs
@@ -84,12 +84,12 @@ namespace Breeze.AspNetCore {
               } else {
                 throw toListTask.Exception;
               }
+            } else {
+              var listResult = EntityQuery.AfterExecution(eq, queryable, toListTask.Result);
+
+              var qr = new QueryResult(listResult, inlineCount);
+              context.Result = new ObjectResult(qr);
             }
-
-            var listResult = EntityQuery.AfterExecution(eq, queryable, toListTask.Result);
-
-            var qr = new QueryResult(listResult, inlineCount);
-            context.Result = new ObjectResult(qr);
           } catch (OperationCanceledException) {
             var emptyResult = new QueryResult(Enumerable.Empty<dynamic>(), null);
             context.Result = new ObjectResult(emptyResult);

--- a/DotNet/Breeze.AspNetCore.NetCore/QueryableExtensions.cs
+++ b/DotNet/Breeze.AspNetCore.NetCore/QueryableExtensions.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Threading;
+using System;
+
+namespace Breeze.AspNetCore.NetCore
+{
+  internal static class QueryableExtensions {
+    // from https://github.com/dotnet/efcore/blob/c6b5eac69fb2ec5dfdb4b990837d8cfdd91753a2/src/EFCore/Extensions/EntityFrameworkQueryableExtensions.cs#L2298
+    internal static async Task<List<TSource>> ToListAsync<TSource>(this IQueryable<TSource> source, CancellationToken cancellationToken = default) {
+      var list = new List<TSource>();
+      await foreach (var element in source.AsAsyncEnumerable().WithCancellation(cancellationToken)) {
+        list.Add(element);
+      }
+
+      return list;
+    }
+    // from https://github.com/dotnet/efcore/blob/c6b5eac69fb2ec5dfdb4b990837d8cfdd91753a2/src/EFCore/Extensions/EntityFrameworkQueryableExtensions.cs#L3131
+    private static IAsyncEnumerable<TSource> AsAsyncEnumerable<TSource>(
+      this IQueryable<TSource> source) {
+      if (source is IAsyncEnumerable<TSource> asyncEnumerable) {
+        return asyncEnumerable;
+      }
+
+      throw new InvalidOperationException("Queryable is not async");
+    }
+  }
+}

--- a/DotNet/Breeze.Core/Query/EntityQueryExtensions.cs
+++ b/DotNet/Breeze.Core/Query/EntityQueryExtensions.cs
@@ -1,7 +1,8 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 
@@ -50,6 +51,24 @@ namespace Breeze.Core {
         
       }
       return queryable;
+    }
+    // from https://github.com/dotnet/efcore/blob/c6b5eac69fb2ec5dfdb4b990837d8cfdd91753a2/src/EFCore/Extensions/EntityFrameworkQueryableExtensions.cs#L2298
+    private static async Task<List<TSource>> ToListAsync<TSource>(this IQueryable<TSource> source, CancellationToken cancellationToken = default) {
+      var list = new List<TSource>();
+      await foreach (var element in source.AsAsyncEnumerable().WithCancellation(cancellationToken)) {
+        list.Add(element);
+      }
+
+      return list;
+    }
+    // from https://github.com/dotnet/efcore/blob/c6b5eac69fb2ec5dfdb4b990837d8cfdd91753a2/src/EFCore/Extensions/EntityFrameworkQueryableExtensions.cs#L3131
+    private static IAsyncEnumerable<TSource> AsAsyncEnumerable<TSource>(
+      this IQueryable<TSource> source) {
+      if (source is IAsyncEnumerable<TSource> asyncEnumerable) {
+        return asyncEnumerable;
+      }
+
+      throw new InvalidOperationException("Queryable is not async");
     }
   }
 }

--- a/DotNet/Breeze.Core/Query/EntityQueryExtensions.cs
+++ b/DotNet/Breeze.Core/Query/EntityQueryExtensions.cs
@@ -52,23 +52,5 @@ namespace Breeze.Core {
       }
       return queryable;
     }
-    // from https://github.com/dotnet/efcore/blob/c6b5eac69fb2ec5dfdb4b990837d8cfdd91753a2/src/EFCore/Extensions/EntityFrameworkQueryableExtensions.cs#L2298
-    private static async Task<List<TSource>> ToListAsync<TSource>(this IQueryable<TSource> source, CancellationToken cancellationToken = default) {
-      var list = new List<TSource>();
-      await foreach (var element in source.AsAsyncEnumerable().WithCancellation(cancellationToken)) {
-        list.Add(element);
-      }
-
-      return list;
-    }
-    // from https://github.com/dotnet/efcore/blob/c6b5eac69fb2ec5dfdb4b990837d8cfdd91753a2/src/EFCore/Extensions/EntityFrameworkQueryableExtensions.cs#L3131
-    private static IAsyncEnumerable<TSource> AsAsyncEnumerable<TSource>(
-      this IQueryable<TSource> source) {
-      if (source is IAsyncEnumerable<TSource> asyncEnumerable) {
-        return asyncEnumerable;
-      }
-
-      throw new InvalidOperationException("Queryable is not async");
-    }
   }
 }


### PR DESCRIPTION
Fixes issue #189

I think this is the best solution to the problem of cancellation tokens. They should be natively supported because the breeze client natively accepts a cancellation token as a parameter when sending a request. Telling people to use an additional filter/middleware to catch an `OperationCanceledException` is not only a klunky solution, but it's hardly even a solution. 

The problem with that approach is the exception won't be thrown until after `ToList()` has completed - it's synchronous. This means the entire database query will still run to completion in entirety, making the exception thrown after pointless. The point of a cancellation token is to stop the database query and save resources. Middleware/additional filters can't do that. To do that, you have to pass the cancellation token to `ToListAsync()`. That function is part of EF so I ported it to this project and made it internal.

I added a variable to the `BreezeQueryFilter` called `CatchCancellations` so this is an **opt in feature** and won't cause any breaking changes.

My solution uses an `IAsyncEnumerable` which isn't part of `netstandard2.0` so I only made my changes in the Dotnet projects. I feel like it should be possible for a solution to be created for AspNetCore but I couldn't find a way to do it.

#### Testing

I was not able to run the unit tests so this was only tested inside of another project. In my testing, everything works as expected. If the CatchCancellations is enabled, the cancellation is detected in ToListAsync, the process is cancelled, and database resources are saved.